### PR TITLE
allow_multiple_stories_in_roElementAction_Replace_&_Insert

### DIFF
--- a/packages/connector/src/MosDevice.ts
+++ b/packages/connector/src/MosDevice.ts
@@ -406,8 +406,9 @@ export class MosDevice implements IMOSDevice {
 				RunningOrderID: this.mosTypes.mosString128.create(data.roElementAction.roID),
 				StoryID: this.mosTypes.mosString128.create((data.roElementAction.element_target || {}).storyID),
 			}
+			const sourceStories = data.roElementAction.element_source.story
 			const stories: Array<IMOSROStory> = MosModel.XMLROStories.fromXML(
-				[data.roElementAction.element_source.story],
+				Array.isArray(sourceStories) ? sourceStories : [sourceStories],
 				this.strict
 			)
 			const resp = await this._callbackOnROInsertStories(action, stories)
@@ -441,8 +442,9 @@ export class MosDevice implements IMOSDevice {
 				RunningOrderID: this.mosTypes.mosString128.create(data.roElementAction.roID),
 				StoryID: this.mosTypes.mosString128.create((data.roElementAction.element_target || {}).storyID),
 			}
+			const sourceStories = data.roElementAction.element_source.story
 			const stories: Array<IMOSROStory> = MosModel.XMLROStories.fromXML(
-				[data.roElementAction.element_source.story],
+				Array.isArray(sourceStories) ? sourceStories : [sourceStories],
 				this.strict
 			)
 			const resp = await this._callbackOnROReplaceStories(action, stories)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When a roElementAction of types Insert or Replace for Stories receives multiple stories in the element_source, it sends a type to the callback that was not expected.

* **What is the new behavior (if this is a feature change)?**
In this operation, if the parsed element_source is an array, pass the array as a parameter. If it's not an array, build an array with the element_source value.


* **Other information**:
It could be nice to have a test to check the change
