### PR TITLE
Fix: primary down upon first connect

### DIFF
--- a/packages/connector/src/__mocks__/socket.ts
+++ b/packages/connector/src/__mocks__/socket.ts
@@ -105,12 +105,6 @@ export class SocketMock extends EventEmitter implements Socket {
 		this.connectedPort = port
 		this.connectedHost = host
 
-		if (this.connectedPort === 10542) {
-			// don't reply on heartbeats on query port
-			this._autoReplyToHeartBeat = false
-		}
-
-		this.emit('connect')
 		return this
 	}
 	setEncoding(): this {
@@ -195,6 +189,14 @@ export class SocketMock extends EventEmitter implements Socket {
 
 	// ------------------------------------------------------------------------
 	// Mock methods:
+	mockEmitConnected(): void {
+		if (this.connectedPort === 10542) {
+			// don't reply on heartbeats on query port
+			this._autoReplyToHeartBeat = false
+		}
+
+		this.emit('connect')
+	}
 	mockSentMessage0(data: unknown, encoding: string): void {
 		if (this._autoReplyToHeartBeat) {
 			const str: string = typeof data === 'string' ? data : this.decode(data as any)

--- a/packages/connector/src/__tests__/lib.ts
+++ b/packages/connector/src/__tests__/lib.ts
@@ -80,7 +80,11 @@ export async function getMosDevice(mos: MosConnection): Promise<MosDevice> {
 		},
 	})
 
-	await delay(10) // to allow for async timers & events to triggered
+	for (const i of SocketMock.instances) {
+		i.mockEmitConnected()
+	}
+
+	await delay(320) // to allow for async timers & events to triggered
 
 	return Promise.resolve(device)
 }
@@ -204,6 +208,10 @@ export function doBeforeAll(): {
 	serverSocketMockLower.name = 'serverLower'
 	serverSocketMockUpper.name = 'serverUpper'
 	serverSocketMockQuery.name = 'serverQuery'
+
+	socketMockLower.mockEmitConnected()
+	socketMockUpper.mockEmitConnected()
+	socketMockQuery.mockEmitConnected()
 
 	return {
 		socketMockLower,

--- a/packages/connector/src/connection/mosSocketClient.ts
+++ b/packages/connector/src/connection/mosSocketClient.ts
@@ -169,6 +169,11 @@ export class MosSocketClient extends EventEmitter {
 			}
 		}
 	}
+	/**
+	 * Returns a queue of messages to be executed by a different connection.
+	 * Will exclude hearbeats from the returned queue. The heartbeats must stay inside
+	 * the internal queue because they are needed for the connection lifecycle.
+	 */
 	handOverQueue(): HandedOverQueue {
 		const queuedHeartbeats = this._queueMessages.filter((m) => m.msg instanceof MosModel.HeartBeat)
 		const heartBeatCBs = Object.fromEntries(

--- a/packages/connector/src/connection/mosSocketClient.ts
+++ b/packages/connector/src/connection/mosSocketClient.ts
@@ -100,8 +100,6 @@ export class MosSocketClient extends EventEmitter {
 				}
 
 				// connect:
-				this.debugTrace(new Date(), `Socket ${this._description} attempting connection`)
-				this.debugTrace('port', this._port, 'host', this._host)
 				this._client.connect(this._port, this._host)
 				this._shouldBeConnected = true
 				this._lastConnectionAttempt = Date.now()
@@ -131,7 +129,6 @@ export class MosSocketClient extends EventEmitter {
 	}
 	processQueue(): void {
 		if (this._disposed) return
-		// this.debugTrace('this.connected', this.connected)
 		if (!this._sentMessage && this.connected) {
 			if (this.processQueueTimeout) {
 				clearTimeout(this.processQueueTimeout)
@@ -173,10 +170,14 @@ export class MosSocketClient extends EventEmitter {
 		}
 	}
 	handOverQueue(): HandedOverQueue {
-		const queue = {
-			messages: this._queueMessages,
-			callbacks: this._queueCallback,
-		}
+		const queuedHeartbeats = this._queueMessages.filter((m) => m.msg instanceof MosModel.HeartBeat)
+		const heartBeatCBs = Object.fromEntries(
+			queuedHeartbeats.map((hb) => [hb.msg.messageID + '', this._queueCallback[hb.msg.messageID]])
+		)
+		const messages = this._queueMessages.filter((m) => !(m.msg instanceof MosModel.HeartBeat))
+		const callbacks = Object.fromEntries(
+			messages.map((m) => [m.msg.messageID, this._queueCallback[m.msg.messageID]])
+		)
 		if (this._sentMessage && this._sentMessage.msg instanceof MosModel.HeartBeat) {
 			// Temporary hack, to allow heartbeats to be received after a handover:
 			this._lingeringMessage = this._sentMessage
@@ -186,14 +187,17 @@ export class MosSocketClient extends EventEmitter {
 			delete this._lingeringCallback[this._lingeringMessage.msg.messageID + '']
 			this._lingeringMessage = null
 		}
-		this._queueMessages = []
-		this._queueCallback = {}
+		this._queueMessages = queuedHeartbeats
+		this._queueCallback = heartBeatCBs
 		this._sentMessage = null
-		if (this.processQueueTimeout) {
+		if (this.processQueueTimeout && !this._queueMessages.length) {
 			clearTimeout(this.processQueueTimeout)
 			delete this.processQueueTimeout
 		}
-		return queue
+		return {
+			messages,
+			callbacks,
+		}
 	}
 
 	/** */


### PR DESCRIPTION
This PR makes a change to the handover logic such that any heartbeat messages will be left in the queue on the specific MOS socket.

This fixes an issue where the primary would never connect _if_ the buddy was up _and_ a command was sent through the mos connection such that a handover was performed.