### PR TITLE
chore: re-add audit dependencies

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -25,6 +25,11 @@ jobs:
           yarn install
         env:
           CI: true
+      - name: Validate dependencies
+        run: |
+          yarn validate:dependencies
+        env:
+          CI: true
   validate-all-dependencies:
     name: Validate all dependencies
     runs-on: ubuntu-latest
@@ -44,10 +49,6 @@ jobs:
           CI: true
       - name: Validate dependencies
         run: |
-          if ! git log --format=oneline -n 1 | grep -q "\[ignore-audit\]"; then
-            yarn validate:dev-dependencies
-          else
-            echo "Skipping audit"
-          fi
+          yarn validate:dev-dependencies
         env:
           CI: true

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -77,6 +77,29 @@ jobs:
       - name: Send coverage
         uses: codecov/codecov-action@v3
 
+  validate-dependencies:
+    name: Validate production dependencies
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Prepare Environment
+        run: |
+          yarn install
+        env:
+          CI: true
+      - name: Validate dependencies
+        run: |
+          yarn validate:dependencies
+        env:
+          CI: true
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/commonPackage.json
+++ b/commonPackage.json
@@ -1,6 +1,9 @@
 {
 	"description": "The properties of this file are automatically copied to all packages' package.json files",
 	"scripts": {
+		"validate:dependencies": "yarn npm audit --environment production && yarn license-validate",
+		"validate:dev-dependencies": "yarn npm audit ",
+		"license-validate": "yarn sofie-licensecheck"
 	},
 	"engines": {
 		"node": ">=14.18.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
 		"test:coverage": "lerna run test --stream -- -- --coverage",
 		"lint-staged": "./node_modules/.bin/lint-staged",
 		"prettier": "cd $INIT_CWD && \"$PROJECT_CWD/node_modules/.bin/prettier\"",
-		"eslint": "cd $INIT_CWD && \"$PROJECT_CWD/node_modules/.bin/eslint\""
+		"eslint": "cd $INIT_CWD && \"$PROJECT_CWD/node_modules/.bin/eslint\"",
+		"validate:dependencies": "yarn lerna exec --parallel yarn validate:dependencies",
+		"validate:dev-dependencies": "yarn lerna exec --parallel yarn validate:dev-dependencies"
 	},
 	"devDependencies": {
 		"@sofie-automation/code-standard-preset": "^2.4.7",

--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -16,7 +16,10 @@
 	"scripts": {
 		"build": "run -T rimraf dist && run build:main",
 		"build:main": "run -T tsc -p tsconfig.build.json",
-		"test": "run -T jest"
+		"test": "run -T jest",
+		"validate:dependencies": "yarn npm audit --environment production && yarn license-validate",
+		"validate:dev-dependencies": "yarn npm audit ",
+		"license-validate": "yarn sofie-licensecheck"
 	},
 	"files": [
 		"/dist",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -14,7 +14,10 @@
 	"scripts": {
 		"build": "run -T rimraf dist && run build:main",
 		"build:main": "run -T tsc -p tsconfig.build.json",
-		"__test": "run -T jest"
+		"__test": "run -T jest",
+		"validate:dependencies": "yarn npm audit --environment production && yarn license-validate",
+		"validate:dev-dependencies": "yarn npm audit ",
+		"license-validate": "yarn sofie-licensecheck"
 	},
 	"engines": {
 		"node": ">=14.18.0"

--- a/packages/helper/package.json
+++ b/packages/helper/package.json
@@ -16,7 +16,10 @@
 	"scripts": {
 		"build": "run -T rimraf dist && run build:main",
 		"build:main": "run -T tsc -p tsconfig.build.json",
-		"test": "run -T jest"
+		"test": "run -T jest",
+		"validate:dependencies": "yarn npm audit --environment production && yarn license-validate",
+		"validate:dev-dependencies": "yarn npm audit ",
+		"license-validate": "yarn sofie-licensecheck"
 	},
 	"files": [
 		"/dist",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -13,7 +13,10 @@
 	"scripts": {
 		"build": "run -T rimraf dist && run build:main",
 		"build:main": "run -T tsc -p tsconfig.build.json",
-		"test": "run -T jest"
+		"test": "run -T jest",
+		"validate:dependencies": "yarn npm audit --environment production && yarn license-validate",
+		"validate:dev-dependencies": "yarn npm audit ",
+		"license-validate": "yarn sofie-licensecheck"
 	},
 	"engines": {
 		"node": ">=14.18.0"

--- a/packages/quick-mos/package.json
+++ b/packages/quick-mos/package.json
@@ -23,7 +23,10 @@
 		"build:main": "run -T tsc -p tsconfig.json",
 		"test": "run -T jest",
 		"inspect": "node --inspect dist/index.js",
-		"start": "ts-node src/index.ts"
+		"start": "ts-node src/index.ts",
+		"validate:dependencies": "yarn npm audit --environment production && yarn license-validate",
+		"validate:dev-dependencies": "yarn npm audit ",
+		"license-validate": "yarn sofie-licensecheck"
 	},
 	"engines": {
 		"node": ">=14.18.0"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
re-adds scripts for auditing dependencies.


* **What is the current behavior?** (You can also link to an open issue here)
Scripts for auditing dependencies where missing after the v3.0.0 refactoring


* **What is the new behavior (if this is a feature change)?**



* **Other information**:
