### PR TITLE
chore: fix issue with yarn license-check

### DIFF
--- a/commonPackage.json
+++ b/commonPackage.json
@@ -1,9 +1,12 @@
 {
-	"description": "The properties of this file are automatically copied to all packages' package.json files",
+	"description": "The properties of this file are copied to all packages' package.json files by running `yarn postinstall`",
 	"scripts": {
 		"validate:dependencies": "yarn npm audit --environment production && yarn license-validate",
 		"validate:dev-dependencies": "yarn npm audit ",
 		"license-validate": "yarn sofie-licensecheck"
+	},
+	"devDependencies": {
+		"@sofie-automation/code-standard-preset": "*"
 	},
 	"engines": {
 		"node": ">=14.18.0"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
 		"lint-staged": "./node_modules/.bin/lint-staged",
 		"prettier": "cd $INIT_CWD && \"$PROJECT_CWD/node_modules/.bin/prettier\"",
 		"eslint": "cd $INIT_CWD && \"$PROJECT_CWD/node_modules/.bin/eslint\"",
-		"validate:dependencies": "yarn lerna exec --parallel yarn validate:dependencies",
-		"validate:dev-dependencies": "yarn lerna exec --parallel yarn validate:dev-dependencies"
+		"validate:dependencies": "yarn lerna exec --parallel yarn validate:dependencies && yarn license-validate",
+		"validate:dev-dependencies": "yarn lerna exec --parallel yarn validate:dev-dependencies",
+		"license-validate": "yarn sofie-licensecheck --allowPackages \"@mos-connection/examples@3.0.4;quick-mos@0.0.0\""
 	},
 	"devDependencies": {
 		"@sofie-automation/code-standard-preset": "^2.4.7",

--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -61,5 +61,8 @@
 		"*.{ts,tsx,js,jsx}": [
 			"run -T eslint"
 		]
+	},
+	"devDependencies": {
+		"@sofie-automation/code-standard-preset": "*"
 	}
 }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -39,5 +39,8 @@
 		"/CHANGELOG.md",
 		"/README.md",
 		"/LICENSE"
-	]
+	],
+	"devDependencies": {
+		"@sofie-automation/code-standard-preset": "*"
+	}
 }

--- a/packages/helper/package.json
+++ b/packages/helper/package.json
@@ -60,5 +60,8 @@
 		"*.{ts,tsx,js,jsx}": [
 			"run -T eslint"
 		]
+	},
+	"devDependencies": {
+		"@sofie-automation/code-standard-preset": "*"
 	}
 }

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -35,5 +35,8 @@
 		"/CHANGELOG.md",
 		"/README.md",
 		"/LICENSE"
-	]
+	],
+	"devDependencies": {
+		"@sofie-automation/code-standard-preset": "*"
+	}
 }

--- a/packages/quick-mos/package.json
+++ b/packages/quick-mos/package.json
@@ -32,6 +32,7 @@
 		"node": ">=14.18.0"
 	},
 	"devDependencies": {
+		"@sofie-automation/code-standard-preset": "*",
 		"@types/underscore": "^1.11.5",
 		"ts-node": "^10.9.1"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,6 +954,7 @@ __metadata:
   dependencies:
     "@mos-connection/helper": 3.0.4
     "@mos-connection/model": 3.0.4
+    "@sofie-automation/code-standard-preset": "*"
     iconv-lite: ^0.6.3
     tslib: ^2.5.3
     xml-js: ^1.6.11
@@ -966,6 +967,7 @@ __metadata:
   resolution: "@mos-connection/examples@workspace:packages/examples"
   dependencies:
     "@mos-connection/connector": 3.0.4
+    "@sofie-automation/code-standard-preset": "*"
   languageName: unknown
   linkType: soft
 
@@ -974,6 +976,7 @@ __metadata:
   resolution: "@mos-connection/helper@workspace:packages/helper"
   dependencies:
     "@mos-connection/model": 3.0.4
+    "@sofie-automation/code-standard-preset": "*"
     iconv-lite: ^0.6.3
     tslib: ^2.5.3
     xml-js: ^1.6.11
@@ -984,6 +987,8 @@ __metadata:
 "@mos-connection/model@*, @mos-connection/model@3.0.4, @mos-connection/model@workspace:packages/model":
   version: 0.0.0-use.local
   resolution: "@mos-connection/model@workspace:packages/model"
+  dependencies:
+    "@sofie-automation/code-standard-preset": "*"
   languageName: unknown
   linkType: soft
 
@@ -1553,7 +1558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sofie-automation/code-standard-preset@npm:^2.4.7":
+"@sofie-automation/code-standard-preset@npm:*, @sofie-automation/code-standard-preset@npm:^2.4.7":
   version: 2.4.7
   resolution: "@sofie-automation/code-standard-preset@npm:2.4.7"
   dependencies:
@@ -7754,6 +7759,7 @@ __metadata:
   dependencies:
     "@mos-connection/connector": "*"
     "@mos-connection/model": "*"
+    "@sofie-automation/code-standard-preset": "*"
     "@types/underscore": ^1.11.5
     chokidar: ^3.5.3
     fast-clone: ^1.5.13


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes an issue with `yarn license-check` which currently doesn't work.


* **What is the current behavior?** (You can also link to an open issue here)
```
Usage Error: Couldn't find a script named "sofie-licensecheck".
```
https://github.com/nrkno/sofie-mos-connection/actions/runs/5805609295/job/15736985452


* **What is the new behavior (if this is a feature change)?**
```
Package "jackspeak@2.2.1" is licensed under "BlueOak-1.0.0" which is not permitted by the --onlyAllow flag. Exiting.
```
https://github.com/nrkno/sofie-mos-connection/actions/runs/5806016310/job/15738093109

Which is a better error. After merge of https://github.com/nrkno/sofie-code-standard-preset/pull/20 this PR should be updated.

* **Other information**:
