### PR TITLE
fix: case roStorySend one storyItem

### DIFF
--- a/packages/connector/src/__mocks__/testData.ts
+++ b/packages/connector/src/__mocks__/testData.ts
@@ -118,6 +118,7 @@ const xmlData = {
    01 ett navn 1:  2:
    01 ett navn 1:  2:
    24 foto/red 1:Foto og redigering:  2:   SAK BUSKERUD;SAK-20</MOSSlugs>   <Owner>LINUXENPS</Owner>   <pubApproved>0</pubApproved>   <SourceMediaTime>0</SourceMediaTime>   <SourceTextTime>0</SourceTextTime>   <StoryProducer>DKTE</StoryProducer>   <TextTime>0</TextTime>   <mosartType>FULL</mosartType>   <ENPSItemType>3</ENPSItemType>   </mosPayload>   </mosExternalMetadata>   </roStorySend>`,
+	roStorySendSingle: `<roStorySend><roID>roID0</roID><storyID>story0</storyID><storySlug>My Story</storySlug><storyNum/><storyBody><storyItem><itemID>item0</itemID><itemSlug/><objID>object0</objID><mosID>mos0</mosID><itemTrigger>CHAINED</itemTrigger></storyItem></storyBody></roStorySend>`,
 	roListAll: `<roListAll>      <ro>   	 <roID>5PM</roID>   	 <roSlug>5PM Rundown</roSlug>   	 <roChannel></roChannel>   	 <roEdStart>2009-07-11T17:00:00</roEdStart>   	 <roEdDur>00:30:00</roEdDur>   	 <roTrigger>MANUAL</roTrigger>   	 <mosExternalMetadata>   	   <mosScope>PLAYLIST</mosScope>   	   <mosSchema>https://ncsA4.com/mos/supported_schemas/NCSAXML2.08</mosSchema>   	   <mosPayload>   		  <Owner>SHOLMES</Owner>   		  <mediaTime>0</mediaTime>   		  <TextTime>278</TextTime>   		  <ModBy>LJOHNSTON</ModBy>   		  <Approved>0</Approved>   		  <Creator>SHOLMES</Creator>   	   </mosPayload>   	</mosExternalMetadata>      </ro>      <ro>   	 <roID>6PM</roID>   	 <roSlug>6PM Rundown</roSlug>   	 <roChannel></roChannel>   	 <roEdStart>2009-07-09T18:00:00</roEdStart>   	 <roEdDur>00:30:00</roEdDur>   	 <roTrigger>MANUAL</roTrigger>   	 <mosExternalMetadata>   	   <mosScope>PLAYLIST</mosScope>   	   <mosSchema>https://ncsA4.com/mos/supported_schemas/NCSAXML2.08</mosSchema>   	   <mosPayload>   		  <Owner>SHOLMES</Owner>   		  <mediaTime>0</mediaTime>   		  <TextTime>350</TextTime>   		  <ModBy>BSMITH</ModBy>   		  <Approved>1</Approved>   		  <Creator>SHOLMES</Creator>   	   </mosPayload>   	</mosExternalMetadata>   	</ro>		</roListAll>`,
 	mosObjCreate: `
 		<mosObjCreate>
@@ -1397,6 +1398,24 @@ const xmlApiData = {
 			// <p> </p>			// <p> </p>
 			// <storyItem><mosID>mosart.morten.mos</mosID><mosAbstract>TIDSMARKØR IKKE RØR</mosAbstract><objID>STORYSTATUS</objID><objSlug>Story status</objSlug><itemID>8</itemID><itemSlug>SAK BUSKERUD;SAK-20</itemSlug></storyItem>
 			// <p> </p>
+		],
+	}),
+	roStorySendSingle: literal<IMOSROFullStory>({
+		ID: mosTypes.mosString128.create('story0'),
+		RunningOrderId: mosTypes.mosString128.create('roID0'),
+		Slug: mosTypes.mosString128.create('My Story'),
+		Body: [
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'storyItem',
+				Content: literal<IMOSItem>({
+					ID: mosTypes.mosString128.create('item0'),
+
+					ObjectID: mosTypes.mosString128.create('object0'),
+					MOSID: 'mos0',
+
+					Trigger: 'CHAINED',
+				}),
+			}),
 		],
 	}),
 	roListAll: [

--- a/packages/connector/src/__tests__/Profile4.spec.ts
+++ b/packages/connector/src/__tests__/Profile4.spec.ts
@@ -128,6 +128,34 @@ describe('Profile 4', () => {
 		})
 		await checkReplyToServer(serverSocketMockLower, messageId, '<roAck>')
 	})
+	test('onRunningOrderStory-single', async () => {
+		// Fake incoming message on socket:
+
+		const messageId = await fakeIncomingMessage(serverSocketMockLower, xmlData.roStorySendSingle)
+		expect(onROStory).toHaveBeenCalledTimes(1)
+
+		const o = Object.assign({}, xmlApiData.roStorySendSingle)
+		// @ts-ignore optional property
+		delete o.Body
+		expect(onROStory.mock.calls[0][0]).toMatchObject(o)
+
+		expect(fixSnapshot(onROStory.mock.calls)).toMatchSnapshot()
+		xmlApiData.roStorySendSingle.Body.forEach((testItem, key) => {
+			let item: any
+			try {
+				item = onROStory.mock.calls[0][0].Body[key]
+				if (!testItem.Content) delete testItem.Content
+
+				expect(item).toMatchObject(testItem)
+			} catch (e) {
+				console.error(key)
+				console.error('item', item)
+				console.error('testItem', testItem)
+				throw e
+			}
+		})
+		await checkReplyToServer(serverSocketMockLower, messageId, '<roAck>')
+	})
 	test('onRequestAllRunningOrders', async () => {
 		const onRoReqAll = jest.fn(async (): Promise<IMOSRunningOrder[]> => {
 			return [

--- a/packages/connector/src/__tests__/__snapshots__/Profile4.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile4.spec.ts.snap
@@ -737,3 +737,58 @@ exports[`Profile 4 onRunningOrderStory: <mos>
   </roAck>
 </mos>"
 `;
+
+exports[`Profile 4 onRunningOrderStory-single 1`] = `
+[
+  [
+    {
+      "Body": [
+        {
+          "Content": {
+            "ID": {
+              "_mosString128": "item0",
+            },
+            "MOSID": "mos0",
+            "ObjectID": {
+              "_mosString128": "object0",
+            },
+            "Trigger": "CHAINED",
+          },
+          "Type": "storyItem",
+        },
+      ],
+      "ID": {
+        "_mosString128": "story0",
+      },
+      "MosExternalMetaData": undefined,
+      "Number": undefined,
+      "RunningOrderId": {
+        "_mosString128": "roID0",
+      },
+      "Slug": {
+        "_mosString128": "My Story",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Profile 4 onRunningOrderStory-single: <mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>1634</messageID>
+  <roAck>
+    <roID>runningOrderId</roID>
+    <roStatus>OK</roStatus>
+  </roAck>
+</mos> 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>1634</messageID>
+  <roAck>
+    <roID>runningOrderId</roID>
+    <roStatus>OK</roStatus>
+  </roAck>
+</mos>"
+`;

--- a/packages/helper/src/mosModel/profile4/xmlConversion.ts
+++ b/packages/helper/src/mosModel/profile4/xmlConversion.ts
@@ -61,7 +61,7 @@ function fromXMLStoryBody(xml: any, strict: boolean): IMOSROFullStoryBodyItem[] 
 		items.forEach((item) => {
 			const bodyItem: IMOSROFullStoryBodyItem = {
 				Type: 'storyItem',
-				Content: item,
+				Content: XMLMosItem.fromXML(item, strict),
 			}
 			body.push(bodyItem)
 		})


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
When the following message is received:
```
<mos>
	<mosID>mosID</mosID>
	<ncsID>ncsID</ncsID>
	<messageID>messageId</messageID>
	<roStorySend>
		<roID>roID</roID>
		<storyID>story 0</storyID>
		<storySlug>My Story</storySlug>
		<storyNum/>
		<storyBody>
			<storyItem>
				<itemID>item0</itemID>
				<itemSlug/>
				<objID/>
				<mosID/>
				<itemTrigger>CHAINED</itemTrigger>
			</storyItem>
		</storyBody>
	</roStorySend>
</mos>
```

The parser will not parse the content correctly and will not follow the definition of the Interface IMOSItem

* **What is the new behavior (if this is a feature change)?**
Parse the StoryItem with `XMLMosItem.fromXML(item, strict)` function


* **Other information**:
I don't know how to test this behaviour
