### PR TITLE
fix: Support non-spec MOS data better

### DIFF
--- a/packages/connector/src/MosConnection.ts
+++ b/packages/connector/src/MosConnection.ts
@@ -93,8 +93,8 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 		primary.on('warning', (str: string) => {
 			this.emit('warning', 'primary: ' + str)
 		})
-		primary.on('error', (str: string) => {
-			this.emit('error', 'primary: ' + str)
+		primary.on('error', (error: Error) => {
+			this.emit('error', 'primary: ' + error + ' ' + (typeof error === 'object' ? error.stack : ''))
 		})
 		primary.on('info', (str: string) => {
 			this.emit('info', 'primary: ' + str)
@@ -137,8 +137,8 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 			secondary.on('warning', (str: string) => {
 				this.emit('warning', 'secondary: ' + str)
 			})
-			secondary.on('error', (str: string) => {
-				this.emit('error', 'secondary: ' + str)
+			secondary.on('error', (error: Error) => {
+				this.emit('error', 'secondary: ' + error + ' ' + (typeof error === 'object' ? error.stack : ''))
 			})
 			secondary.on('info', (str: string) => {
 				this.emit('info', 'secondary: ' + str)

--- a/packages/connector/src/MosDevice.ts
+++ b/packages/connector/src/MosDevice.ts
@@ -1428,7 +1428,11 @@ export class MosDevice implements IMOSDevice {
 	private badRoAckReply(xmlRoAck: AnyXML) {
 		try {
 			const roAck = MosModel.XMLMosROAck.fromXML(xmlRoAck, this.strict)
-			return new Error(`Reply: ${roAck.toString()}`)
+			return new Error(
+				`Reply: ${this.mosTypes.mosString128.stringify(
+					roAck.Status
+				)}, ID: ${this.mosTypes.mosString128.stringify(roAck.ID)}`
+			)
 		} catch (e) {
 			return new Error(`Reply: Unparsable reply: ${safeStringify(xmlRoAck).slice(0, 200)}`)
 		}

--- a/packages/connector/src/MosDevice.ts
+++ b/packages/connector/src/MosDevice.ts
@@ -788,9 +788,8 @@ export class MosDevice implements IMOSDevice {
 	async requestMachineInfo(): Promise<IMOSListMachInfo> {
 		const message = new MosModel.ReqMachInfo(this.strict)
 
-		const data = await this.executeCommand(message)
-
-		return this.handleParseReply((strict) => MosModel.XMLMosListMachInfo.fromXML(data.mos.listMachInfo, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosListMachInfo.fromXML(reply.mos.listMachInfo, strict))
 	}
 
 	onRequestMachineInfo(cb: () => Promise<IMOSListMachInfo>): void {
@@ -903,8 +902,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendCreateRunningOrder(ro: IMOSRunningOrder): Promise<IMOSROAck> {
 		const message = new MosModel.ROCreate(ro, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 
 	onReplaceRunningOrder(cb: (ro: IMOSRunningOrder) => Promise<IMOSROAck>): void {
@@ -913,8 +912,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendReplaceRunningOrder(ro: IMOSRunningOrder): Promise<IMOSROAck> {
 		const message = new MosModel.ROReplace(ro, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 
 	onDeleteRunningOrder(cb: (runningOrderId: IMOSString128) => Promise<IMOSROAck>): void {
@@ -923,8 +922,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendDeleteRunningOrder(runningOrderId: IMOSString128): Promise<IMOSROAck> {
 		const message = new MosModel.RODelete(runningOrderId, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 
 	onRequestRunningOrder(cb: (runningOrderId: IMOSString128) => Promise<IMOSRunningOrder | null>): void {
@@ -955,8 +954,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendMetadataReplace(metadata: IMOSRunningOrderBase): Promise<IMOSROAck> {
 		const message = new MosModel.ROMetadataReplace(metadata, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 
 	onRunningOrderStatus(cb: (status: IMOSRunningOrderStatus) => Promise<IMOSROAck>): void {
@@ -1050,8 +1049,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendROInsertStories(Action: IMOSStoryAction, Stories: Array<IMOSROStory>): Promise<IMOSROAck> {
 		const message = new MosModel.ROInsertStories(Action, Stories, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onROInsertItems(cb: (Action: IMOSItemAction, Items: Array<IMOSItem>) => Promise<IMOSROAck>): void {
 		this.checkProfile('onROInsertItems', 'profile2')
@@ -1059,8 +1058,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendROInsertItems(Action: IMOSItemAction, Items: Array<IMOSItem>): Promise<IMOSROAck> {
 		const message = new MosModel.ROInsertItems(Action, Items, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onROReplaceStories(cb: (Action: IMOSStoryAction, Stories: Array<IMOSROStory>) => Promise<IMOSROAck>): void {
 		this.checkProfile('onROReplaceStories', 'profile2')
@@ -1068,8 +1067,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendROReplaceStories(Action: IMOSStoryAction, Stories: Array<IMOSROStory>): Promise<IMOSROAck> {
 		const message = new MosModel.ROReplaceStories(Action, Stories, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onROReplaceItems(cb: (Action: IMOSItemAction, Items: Array<IMOSItem>) => Promise<IMOSROAck>): void {
 		this.checkProfile('onROReplaceItems', 'profile2')
@@ -1077,8 +1076,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendROReplaceItems(Action: IMOSItemAction, Items: Array<IMOSItem>): Promise<IMOSROAck> {
 		const message = new MosModel.ROReplaceItems(Action, Items, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onROMoveStories(cb: (Action: IMOSStoryAction, Stories: Array<IMOSString128>) => Promise<IMOSROAck>): void {
 		this.checkProfile('onROMoveStories', 'profile2')
@@ -1086,8 +1085,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendROMoveStories(Action: IMOSStoryAction, Stories: Array<IMOSString128>): Promise<IMOSROAck> {
 		const message = new MosModel.ROMoveStories(Action, Stories, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onROMoveItems(cb: (Action: IMOSItemAction, Items: Array<IMOSString128>) => Promise<IMOSROAck>): void {
 		this.checkProfile('onROMoveItems', 'profile2')
@@ -1095,8 +1094,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendROMoveItems(Action: IMOSItemAction, Items: Array<IMOSString128>): Promise<IMOSROAck> {
 		const message = new MosModel.ROMoveItems(Action, Items, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onRODeleteStories(cb: (Action: IMOSROAction, Stories: Array<IMOSString128>) => Promise<IMOSROAck>): void {
 		this.checkProfile('onRODeleteStories', 'profile2')
@@ -1104,8 +1103,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendRODeleteStories(Action: IMOSROAction, Stories: Array<IMOSString128>): Promise<IMOSROAck> {
 		const message = new MosModel.RODeleteStories(Action, Stories, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onRODeleteItems(cb: (Action: IMOSStoryAction, Items: Array<IMOSString128>) => Promise<IMOSROAck>): void {
 		this.checkProfile('onRODeleteItems', 'profile2')
@@ -1113,8 +1112,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendRODeleteItems(Action: IMOSStoryAction, Items: Array<IMOSString128>): Promise<IMOSROAck> {
 		const message = new MosModel.RODeleteItems(Action, Items, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onROSwapStories(
 		cb: (Action: IMOSROAction, StoryID0: IMOSString128, StoryID1: IMOSString128) => Promise<IMOSROAck>
@@ -1128,8 +1127,8 @@ export class MosDevice implements IMOSDevice {
 		StoryID1: IMOSString128
 	): Promise<IMOSROAck> {
 		const message = new MosModel.ROSwapStories(Action, StoryID0, StoryID1, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 	onROSwapItems(
 		cb: (Action: IMOSStoryAction, ItemID0: IMOSString128, ItemID1: IMOSString128) => Promise<IMOSROAck>
@@ -1139,8 +1138,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendROSwapItems(Action: IMOSStoryAction, ItemID0: IMOSString128, ItemID1: IMOSString128): Promise<IMOSROAck> {
 		const message = new MosModel.ROSwapItems(Action, ItemID0, ItemID1, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 
 	// ============================================================================================================
@@ -1153,8 +1152,8 @@ export class MosDevice implements IMOSDevice {
 
 	async sendObjectCreate(object: IMOSObject): Promise<IMOSAck> {
 		const message = new MosModel.MosObjCreate(object, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosAck.fromXML(data.mos.mosAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosAck.fromXML(reply.mos.mosAck, strict))
 	}
 
 	onItemReplace(cb: (roID: IMOSString128, storyID: IMOSString128, item: IMOSItem) => Promise<IMOSROAck>): void {
@@ -1164,8 +1163,8 @@ export class MosDevice implements IMOSDevice {
 
 	async sendItemReplace(options: MosItemReplaceOptions): Promise<IMOSROAck> {
 		const message = new MosModel.MosItemReplace(options, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 
 	onRequestSearchableSchema(cb: (username: string) => Promise<IMOSListSearchableSchema>): void {
@@ -1175,8 +1174,8 @@ export class MosDevice implements IMOSDevice {
 
 	async sendRequestSearchableSchema(username: string): Promise<IMOSListSearchableSchema> {
 		const message = new MosModel.MosReqSearchableSchema({ username }, this.strict)
-		const response = await this.executeCommand(message)
-		return this.handleParseReply(() => response.mos.mosListSearchableSchema)
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply(() => reply.mos.mosListSearchableSchema)
 	}
 
 	onRequestObjectList(cb: (objList: IMOSRequestObjectList) => Promise<IMOSObjectList>): void {
@@ -1186,10 +1185,10 @@ export class MosDevice implements IMOSDevice {
 
 	async sendRequestObjectList(reqObjList: IMOSRequestObjectList): Promise<IMOSObjectList> {
 		const message = new MosModel.MosReqObjList(reqObjList, this.strict)
-		const response = await this.executeCommand(message)
+		const reply = await this.executeCommand(message)
 
 		return this.handleParseReply((strict) => {
-			const objList = response.mos.mosObjList
+			const objList = reply.mos.mosObjList
 			if (objList.list) objList.list = MosModel.XMLMosObjects.fromXML(objList.list.mosObj, strict)
 			return objList
 		})
@@ -1201,8 +1200,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendRequestObjectActionNew(obj: IMOSObject): Promise<IMOSAck> {
 		const message = new MosModel.MosReqObjActionNew({ object: obj }, this.strict)
-		const response = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosAck.fromXML(response.mos.mosAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosAck.fromXML(reply.mos.mosAck, strict))
 	}
 
 	onRequestObjectActionUpdate(cb: (objId: IMOSString128, obj: IMOSObject) => Promise<IMOSAck>): void {
@@ -1211,8 +1210,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendRequestObjectActionUpdate(objId: IMOSString128, obj: IMOSObject): Promise<IMOSAck> {
 		const message = new MosModel.MosReqObjActionUpdate({ object: obj, objectId: objId }, this.strict)
-		const response = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosAck.fromXML(response.mos.mosAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosAck.fromXML(reply.mos.mosAck, strict))
 	}
 	onRequestObjectActionDelete(cb: (objId: IMOSString128) => Promise<IMOSAck>): void {
 		this.checkProfile('onRequestObjectActionDelete', 'profile3')
@@ -1220,8 +1219,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendRequestObjectActionDelete(objId: IMOSString128): Promise<IMOSAck> {
 		const message = new MosModel.MosReqObjActionDelete({ objectId: objId }, this.strict)
-		const response = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosAck.fromXML(response.mos.mosAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosAck.fromXML(reply.mos.mosAck, strict))
 	}
 
 	// Deprecated methods:
@@ -1296,8 +1295,8 @@ export class MosDevice implements IMOSDevice {
 	}
 	async sendRunningOrderStory(story: IMOSROFullStory): Promise<IMOSROAck> {
 		const message = new MosModel.ROStory(story, this.strict)
-		const data = await this.executeCommand(message)
-		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(data.mos.roAck, strict))
+		const reply = await this.executeCommand(message)
+		return this.handleParseReply((strict) => MosModel.XMLMosROAck.fromXML(reply.mos.roAck, strict))
 	}
 
 	// Deprecated methods:
@@ -1362,13 +1361,6 @@ export class MosDevice implements IMOSDevice {
 			}
 		} else {
 			throw new Error(`Unable to send message due to no current connection`)
-		}
-	}
-	private getCommandTimeout(): number {
-		if (this._currentConnection) {
-			return this._currentConnection.timeout
-		} else {
-			throw new Error(`No current connection`)
 		}
 	}
 	private switchConnections(): void {
@@ -1439,17 +1431,6 @@ export class MosDevice implements IMOSDevice {
 			return new Error(`Reply: ${roAck.toString()}`)
 		} catch (e) {
 			return new Error(`Reply: Unparsable reply: ${safeStringify(xmlRoAck).slice(0, 200)}`)
-		}
-	}
-	/** Will throw if the mosAck is not okay */
-	private handleMosAckReply(xmlMosAck: AnyXML): void {
-		try {
-			const mosAck = MosModel.XMLMosAck.fromXML(xmlMosAck, this.strict)
-			if (mosAck.Status !== IMOSAckStatus.ACK) {
-				throw new Error(`Reply: ${mosAck.toString()}`)
-			}
-		} catch (e) {
-			throw new Error(`Reply: Unparsable reply: ${safeStringify(xmlMosAck).slice(0, 200)}`)
 		}
 	}
 	/** throws if there is an error */

--- a/packages/connector/src/__mocks__/socket.ts
+++ b/packages/connector/src/__mocks__/socket.ts
@@ -212,7 +212,7 @@ export class SocketMock extends EventEmitter implements Socket {
 <ncsID>${ncsID}</ncsID>
 <messageID>${messageId}</messageID>\
   <heartbeat>
-    <time>${mosTypes.mosTime.stringify(mosTypes.mosTime.create(undefined))}</time>
+    <time>${mosTypes.mosTime.stringify(mosTypes.mosTime.create(Date.now()))}</time>
   </heartbeat>
 </mos>\r\n`
 					this.mockReceiveMessage(this.encode(repl))

--- a/packages/connector/src/__mocks__/socket.ts
+++ b/packages/connector/src/__mocks__/socket.ts
@@ -285,6 +285,9 @@ export class SocketMock extends EventEmitter implements Socket {
 	setAutoReplyToHeartBeat(autoReplyToHeartBeat: boolean): void {
 		this._autoReplyToHeartBeat = autoReplyToHeartBeat
 	}
+	get autoReplyToHeartBeat(): boolean {
+		return this._autoReplyToHeartBeat
+	}
 }
 
 type SimpleTypes = string | string[] | false | Buffer | Buffer[]

--- a/packages/connector/src/__mocks__/testData.ts
+++ b/packages/connector/src/__mocks__/testData.ts
@@ -489,6 +489,30 @@ const xmlApiData = {
 			profile1: true,
 		},
 	}),
+	machineInfoReply: literal<IMOSListMachInfo>({
+		manufacturer: mosTypes.mosString128.create('RadioVision, Ltd.'),
+		model: mosTypes.mosString128.create('TCS6000'),
+		hwRev: mosTypes.mosString128.create(''),
+		swRev: mosTypes.mosString128.create('2.1.0.37'),
+		DOM: mosTypes.mosString128.create(''),
+		SN: mosTypes.mosString128.create('927748927'),
+		ID: mosTypes.mosString128.create('airchache.newscenter.com'),
+		time: mosTypes.mosTime.create('2009-04-11T17:20:42'),
+		opTime: mosTypes.mosTime.create('2009-03-01T23:55:10'),
+		mosRev: mosTypes.mosString128.create('2.8.2'),
+
+		supportedProfiles: {
+			deviceType: 'NCS',
+			profile0: true,
+			profile1: true,
+			profile2: true,
+			profile3: true,
+			profile4: true,
+			profile5: true,
+			profile6: true,
+			profile7: true,
+		},
+	}),
 	mosObj: literal<IMOSObject>({
 		ID: mosTypes.mosString128.create('M000123'),
 		Slug: mosTypes.mosString128.create('My new object'),
@@ -1085,7 +1109,7 @@ const xmlApiData = {
 		literal<IMOSROStory>({
 			ID: mosTypes.mosString128.create('17'),
 			Items: [],
-			Slug: mosTypes.mosString128.create(undefined),
+			Slug: undefined,
 		}),
 	],
 	roElementAction_insert_item_Action: literal<IMOSItemAction>({
@@ -1174,7 +1198,7 @@ const xmlApiData = {
 		literal<IMOSROStory>({
 			ID: mosTypes.mosString128.create('17'),
 			Items: [],
-			Slug: mosTypes.mosString128.create(undefined),
+			Slug: undefined,
 			// MosExternalMetaData?: Array<IMOSExternalMetaData>,
 		}),
 	],

--- a/packages/connector/src/__tests__/MessageChunking.spec.ts
+++ b/packages/connector/src/__tests__/MessageChunking.spec.ts
@@ -247,11 +247,11 @@ describe('message chunking', () => {
 		const chunks = [message.message.slice(0, 100), message.message.slice(100)]
 
 		// Send first part of the message:
-		await sendFakeIncomingMessage(serverSocketMockLower, chunks[0])
+		sendFakeIncomingMessage(serverSocketMockLower, chunks[0])
 		expect(onRequestMOSObject).toHaveBeenCalledTimes(0)
 
 		// Send rest of the message:
-		await sendFakeIncomingMessage(serverSocketMockLower, chunks[1])
+		sendFakeIncomingMessage(serverSocketMockLower, chunks[1])
 		expect(onRequestMOSObject).toHaveBeenCalledTimes(1)
 	})
 
@@ -281,13 +281,13 @@ describe('message chunking', () => {
 		]
 
 		// Send the parts of the message:
-		await sendFakeIncomingMessage(serverSocketMockLower, chunks[0])
+		sendFakeIncomingMessage(serverSocketMockLower, chunks[0])
 		expect(onRequestMOSObject).toHaveBeenCalledTimes(0)
-		await sendFakeIncomingMessage(serverSocketMockLower, chunks[1])
+		sendFakeIncomingMessage(serverSocketMockLower, chunks[1])
 		expect(onRequestMOSObject).toHaveBeenCalledTimes(0)
-		await sendFakeIncomingMessage(serverSocketMockLower, chunks[2])
+		sendFakeIncomingMessage(serverSocketMockLower, chunks[2])
 		expect(onRequestMOSObject).toHaveBeenCalledTimes(0)
-		await sendFakeIncomingMessage(serverSocketMockLower, chunks[2])
+		sendFakeIncomingMessage(serverSocketMockLower, chunks[2])
 		expect(onRequestMOSObject).toHaveBeenCalledTimes(1)
 	})
 	test('multiple messages', async () => {
@@ -308,7 +308,7 @@ describe('message chunking', () => {
 		)
 
 		// Send both messages right away:
-		await sendFakeIncomingMessage(serverSocketMockLower, message0.message + message1.message)
+		sendFakeIncomingMessage(serverSocketMockLower, message0.message + message1.message)
 		expect(onRequestMOSObject).toHaveBeenCalledTimes(2)
 	})
 })

--- a/packages/connector/src/__tests__/MosConnection.spec.ts
+++ b/packages/connector/src/__tests__/MosConnection.spec.ts
@@ -72,6 +72,11 @@ describe('MosDevice: General', () => {
 			})
 		)
 
+		const onError = jest.fn((e) => console.log(e))
+		const onWarning = jest.fn((e) => console.log(e))
+		mos.on('error', onError)
+		mos.on('warning', onWarning)
+
 		expect(mos.profiles).toMatchObject({
 			'0': true,
 			'1': true,
@@ -82,6 +87,9 @@ describe('MosDevice: General', () => {
 			'6': false,
 			'7': false,
 		})
+
+		expect(onError).toHaveBeenCalledTimes(0)
+		expect(onWarning).toHaveBeenCalledTimes(0)
 
 		await mos.dispose()
 	})
@@ -94,10 +102,17 @@ describe('MosDevice: General', () => {
 				'1': true,
 			},
 		})
+		const onError = jest.fn((e) => console.log(e))
+		const onWarning = jest.fn((e) => console.log(e))
+		mos.on('error', onError)
+		mos.on('warning', onWarning)
 		expect(mos.acceptsConnections).toBe(true)
 		await initMosConnection(mos)
 		expect(mos.isListening).toBe(true)
 		expect(SocketMock.instances).toHaveLength(0)
+
+		expect(onError).toHaveBeenCalledTimes(0)
+		expect(onWarning).toHaveBeenCalledTimes(0)
 
 		// close sockets after test
 		await mos.dispose()
@@ -111,6 +126,11 @@ describe('MosDevice: General', () => {
 				'1': true,
 			},
 		})
+		const onError = jest.fn((e) => console.log(e))
+		const onWarning = jest.fn((e) => console.log(e))
+		mos.on('error', onError)
+		mos.on('warning', onWarning)
+
 		expect(mos.acceptsConnections).toBe(true)
 		await initMosConnection(mos)
 		expect(mos.isListening).toBe(true)
@@ -146,6 +166,9 @@ describe('MosDevice: General', () => {
 		expect(SocketMock.instances[2].destroy).toHaveBeenCalledTimes(1)
 		expect(SocketMock.instances[3].destroy).toHaveBeenCalledTimes(1)
 
+		expect(onError).toHaveBeenCalledTimes(0)
+		expect(onWarning).toHaveBeenCalledTimes(0)
+
 		expect(mosDevice.hasConnection).toEqual(false)
 	})
 	test('MosDevice secondary', async () => {
@@ -157,6 +180,11 @@ describe('MosDevice: General', () => {
 				'1': true,
 			},
 		})
+		const onError = jest.fn((e) => console.log(e))
+		const onWarning = jest.fn((e) => console.log(e))
+		mos.on('error', onError)
+		mos.on('warning', onWarning)
+
 		expect(mos.acceptsConnections).toBe(true)
 		await initMosConnection(mos)
 		expect(mos.isListening).toBe(true)
@@ -236,6 +264,9 @@ describe('MosDevice: General', () => {
 		returnedObj = await mosDevice.sendRequestMOSObject(xmlApiData.mosObj.ID)
 		expect(returnedObj).toBeTruthy()
 
+		expect(onError).toHaveBeenCalledTimes(0)
+		expect(onWarning).toHaveBeenCalledTimes(0)
+
 		await mos.dispose()
 	})
 	test('init and connectionStatusChanged', async () => {
@@ -252,6 +283,11 @@ describe('MosDevice: General', () => {
 				},
 			})
 		)
+		const onError = jest.fn((e) => console.log(e))
+		const onWarning = jest.fn((e) => console.log(e))
+		mosConnection.on('error', onError)
+		mosConnection.on('warning', onWarning)
+
 		await initMosConnection(mosConnection)
 
 		const mosDevice = await mosConnection.connect({
@@ -299,6 +335,10 @@ describe('MosDevice: General', () => {
 		// mock cause timeout
 
 		mosConnection.checkProfileValidness()
+
+		expect(onError).toHaveBeenCalledTimes(0)
+		expect(onWarning).toHaveBeenCalledTimes(0)
+
 		await mosConnection.dispose()
 	})
 	test('buddy failover', async () => {
@@ -310,6 +350,14 @@ describe('MosDevice: General', () => {
 				'1': true,
 			},
 		})
+		const onError = jest.fn((e) => console.log(e))
+		const onWarning = jest.fn((e) => console.log(e))
+		mos.on('error', (e) => {
+			// filter out heartbeat errors:
+			if (!(e + '').match(/heartbeat.*timed out/i)) onError(e)
+		})
+		mos.on('warning', onWarning)
+
 		await initMosConnection(mos)
 		const mosDevice: MosDevice = await mos.connect({
 			primary: {
@@ -382,6 +430,9 @@ describe('MosDevice: General', () => {
 		expect(connMocks[1].destroy).toHaveBeenCalledTimes(1)
 		expect(connMocks[2].destroy).toHaveBeenCalledTimes(1)
 
+		expect(onError).toHaveBeenCalledTimes(0)
+		expect(onWarning).toHaveBeenCalledTimes(0)
+
 		await mos.dispose()
 	})
 	test('buddy failover - primary starts offline', async () => {
@@ -393,6 +444,14 @@ describe('MosDevice: General', () => {
 				'1': true,
 			},
 		})
+		const onError = jest.fn((e) => console.log(e))
+		const onWarning = jest.fn((e) => console.log(e))
+		mos.on('error', (e) => {
+			// filter out heartbeat errors:
+			if (!(e + '').match(/heartbeat.*timed out/i)) onError(e)
+		})
+		mos.on('warning', onWarning)
+
 		await initMosConnection(mos)
 		const mosDevice: MosDevice = await mos.connect({
 			primary: {
@@ -470,6 +529,9 @@ describe('MosDevice: General', () => {
 
 		expect(connMocks[1].destroy).toHaveBeenCalledTimes(1)
 		expect(connMocks[2].destroy).toHaveBeenCalledTimes(1)
+
+		expect(onError).toHaveBeenCalledTimes(0)
+		expect(onWarning).toHaveBeenCalledTimes(0)
 
 		await mos.dispose()
 	})

--- a/packages/connector/src/__tests__/Profile0-non-strict.spec.ts
+++ b/packages/connector/src/__tests__/Profile0-non-strict.spec.ts
@@ -170,7 +170,7 @@ describe('Profile 0 - non strict', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid timestamp/i)
+		expect(String(caughtError)).toMatch(/Unable to parse MOS reply.*Invalid timestamp/i)
 	})
 	test('requestMachineInfo - missing <opTime>', async () => {
 		// Prepare mock server response:
@@ -236,6 +236,6 @@ describe('Profile 0 - non strict', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid timestamp/i)
+		expect(String(caughtError)).toMatch(/Unable to parse MOS reply.*Invalid timestamp/i)
 	})
 })

--- a/packages/connector/src/__tests__/Profile0-non-strict.spec.ts
+++ b/packages/connector/src/__tests__/Profile0-non-strict.spec.ts
@@ -104,6 +104,30 @@ describe('Profile 0 - non strict', () => {
 		expect(socketMockUpper).toBeTruthy()
 		expect(serverSocketMockLower).toBeTruthy()
 	})
+	test('requestMachineInfo - missing <time>', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const messageID = getMessageId(str)
+			const replyMessage = xmlData.machineInfo.replace(/<time>.*<\/time>/, '')
+			const repl = getXMLReply(messageID, replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		const returnedMachineInfo: IMOSListMachInfo = await mosDevice.requestMachineInfo()
+		expect(mockReply).toHaveBeenCalledTimes(1)
+		const msg = decode(mockReply.mock.calls[0][0])
+		expect(msg).toMatch(/<reqMachInfo\/>/)
+		checkMessageSnapshot(msg)
+
+		const replyMessage = { ...xmlApiData.machineInfoReply }
+		replyMessage.time = mosTypes.mosTime.fallback()
+
+		expect(returnedMachineInfo).toMatchObject(replyMessage)
+		// expect(returnedMachineInfo.opTime).toBeUndefined()
+	})
 	test('requestMachineInfo - empty <time>', async () => {
 		// Prepare mock server response:
 		const mockReply = jest.fn((data) => {
@@ -134,6 +158,72 @@ describe('Profile 0 - non strict', () => {
 			const str = decode(data)
 			const messageID = getMessageId(str)
 			const replyMessage = xmlData.machineInfo.replace(/<time>.*<\/time>/, '<time>BAD DATA</time>')
+			const repl = getXMLReply(messageID, replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		let caughtError: Error | undefined = undefined
+		await mosDevice.requestMachineInfo().catch((err) => {
+			caughtError = err
+		})
+		expect(mockReply).toHaveBeenCalledTimes(1)
+
+		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid timestamp/i)
+	})
+	test('requestMachineInfo - missing <opTime>', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const replyMessage = xmlData.machineInfo.replace(/<opTime>.*<\/opTime>/, '')
+			const repl = getXMLReply(getMessageId(str), replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		const returnedMachineInfo: IMOSListMachInfo = await mosDevice.requestMachineInfo()
+		expect(mockReply).toHaveBeenCalledTimes(1)
+		const msg = decode(mockReply.mock.calls[0][0])
+		expect(msg).toMatch(/<reqMachInfo\/>/)
+		checkMessageSnapshot(msg)
+
+		const replyMessage = { ...xmlApiData.machineInfoReply }
+		replyMessage.opTime = undefined
+
+		expect(returnedMachineInfo).toMatchObject(replyMessage)
+		expect(returnedMachineInfo.opTime).toBeUndefined()
+	})
+	test('requestMachineInfo - empty <opTime>', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const replyMessage = xmlData.machineInfo.replace(/<opTime>.*<\/opTime>/, '<opTime></opTime>')
+			const repl = getXMLReply(getMessageId(str), replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		const returnedMachineInfo: IMOSListMachInfo = await mosDevice.requestMachineInfo()
+		expect(mockReply).toHaveBeenCalledTimes(1)
+		const msg = decode(mockReply.mock.calls[0][0])
+		expect(msg).toMatch(/<reqMachInfo\/>/)
+		checkMessageSnapshot(msg)
+
+		const replyMessage = { ...xmlApiData.machineInfoReply }
+		replyMessage.opTime = undefined
+
+		expect(returnedMachineInfo).toMatchObject(replyMessage)
+		expect(returnedMachineInfo.opTime).toBeUndefined()
+	})
+	test('requestMachineInfo - bad formatted <opTime>', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const messageID = getMessageId(str)
+			const replyMessage = xmlData.machineInfo.replace(/<opTime>.*<\/opTime>/, '<opTime>>BAD DATA</opTime>')
 			const repl = getXMLReply(messageID, replyMessage)
 			return encode(repl)
 		})

--- a/packages/connector/src/__tests__/Profile0-non-strict.spec.ts
+++ b/packages/connector/src/__tests__/Profile0-non-strict.spec.ts
@@ -1,0 +1,151 @@
+import {
+	checkMessageSnapshot,
+	clearMocks,
+	decode,
+	doBeforeAll,
+	encode,
+	getMessageId,
+	getMosConnection,
+	getMosDevice,
+	getXMLReply,
+	mosTypes,
+	setupMocks,
+} from './lib'
+import { MosConnection, MosDevice, IMOSObject, IMOSListMachInfo } from '..'
+import { SocketMock } from '../__mocks__/socket'
+import { xmlData, xmlApiData } from '../__mocks__/testData'
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// @ts-ignore imports are unused
+import { Socket } from 'net'
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+beforeAll(() => {
+	setupMocks()
+})
+beforeEach(() => {
+	clearMocks()
+})
+describe('Profile 0 - non strict', () => {
+	let mosDevice: MosDevice
+	let mosConnection: MosConnection
+
+	let socketMockLower: SocketMock
+	let socketMockUpper: SocketMock
+	let socketMockQuery: SocketMock
+
+	let serverSocketMockLower: SocketMock
+	let serverSocketMockUpper: SocketMock
+	let serverSocketMockQuery: SocketMock
+
+	let onRequestMachineInfo: jest.Mock<any, any>
+	let onRequestMOSObject: jest.Mock<any, any>
+	let onRequestAllMOSObjects: jest.Mock<any, any>
+
+	beforeAll(async () => {
+		mosConnection = await getMosConnection(
+			{
+				'0': true,
+				'1': true, // Must support at least one other profile
+			},
+			false
+		)
+		mosDevice = await getMosDevice(mosConnection)
+
+		// Profile 0:
+		onRequestMachineInfo = jest.fn(async () => {
+			return xmlApiData.machineInfo
+		})
+		mosDevice.onRequestMachineInfo(async (): Promise<IMOSListMachInfo> => {
+			return onRequestMachineInfo()
+		})
+		// Profile 1:
+		onRequestMOSObject = jest.fn(async () => {
+			return xmlApiData.mosObj
+		})
+		onRequestAllMOSObjects = jest.fn(async () => {
+			return [xmlApiData.mosObj, xmlApiData.mosObj2]
+		})
+		mosDevice.onRequestMOSObject(async (objId: string): Promise<IMOSObject | null> => {
+			return onRequestMOSObject(objId)
+		})
+		mosDevice.onRequestAllMOSObjects(async (): Promise<Array<IMOSObject>> => {
+			return onRequestAllMOSObjects()
+		})
+		const b = doBeforeAll()
+		socketMockLower = b.socketMockLower
+		socketMockUpper = b.socketMockUpper
+		socketMockQuery = b.socketMockQuery
+		serverSocketMockLower = b.serverSocketMockLower
+		serverSocketMockUpper = b.serverSocketMockUpper
+		serverSocketMockQuery = b.serverSocketMockQuery
+
+		mosDevice.checkProfileValidness()
+		mosConnection.checkProfileValidness()
+	})
+	afterAll(async () => {
+		await mosDevice.dispose()
+		await mosConnection.dispose()
+	})
+	beforeEach(() => {
+		onRequestMOSObject.mockClear()
+		onRequestAllMOSObjects.mockClear()
+
+		serverSocketMockLower.mockClear()
+		serverSocketMockUpper.mockClear()
+		if (serverSocketMockQuery) serverSocketMockQuery.mockClear()
+		socketMockLower.mockClear()
+		socketMockUpper.mockClear()
+		if (socketMockQuery) socketMockQuery.mockClear()
+	})
+	test('init', async () => {
+		expect(mosDevice).toBeTruthy()
+		expect(socketMockLower).toBeTruthy()
+		expect(socketMockUpper).toBeTruthy()
+		expect(serverSocketMockLower).toBeTruthy()
+	})
+	test('requestMachineInfo - empty <time>', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const messageID = getMessageId(str)
+			const replyMessage = xmlData.machineInfo.replace(/<time>.*<\/time>/, '<time></time>')
+			const repl = getXMLReply(messageID, replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		const returnedMachineInfo: IMOSListMachInfo = await mosDevice.requestMachineInfo()
+		expect(mockReply).toHaveBeenCalledTimes(1)
+		const msg = decode(mockReply.mock.calls[0][0])
+		expect(msg).toMatch(/<reqMachInfo\/>/)
+		checkMessageSnapshot(msg)
+
+		const replyMessage = { ...xmlApiData.machineInfoReply }
+		replyMessage.time = mosTypes.mosTime.fallback()
+
+		expect(returnedMachineInfo).toMatchObject(replyMessage)
+		// expect(returnedMachineInfo.opTime).toBeUndefined()
+	})
+	test('requestMachineInfo - bad formatted <time>', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const messageID = getMessageId(str)
+			const replyMessage = xmlData.machineInfo.replace(/<time>.*<\/time>/, '<time>BAD DATA</time>')
+			const repl = getXMLReply(messageID, replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		let caughtError: Error | undefined = undefined
+		await mosDevice.requestMachineInfo().catch((err) => {
+			caughtError = err
+		})
+		expect(mockReply).toHaveBeenCalledTimes(1)
+
+		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid timestamp/i)
+	})
+})

--- a/packages/connector/src/__tests__/Profile0.spec.ts
+++ b/packages/connector/src/__tests__/Profile0.spec.ts
@@ -283,7 +283,7 @@ describe('Profile 0', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*listMachInfo.opTime.*Invalid timestamp/i)
+		expect(String(caughtError)).toMatch(/Unable to parse MOS reply.*listMachInfo.opTime.*Invalid timestamp/i)
 	})
 	test('requestMachineInfo - missing <time>', async () => {
 		// Prepare mock server response:
@@ -302,7 +302,7 @@ describe('Profile 0', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*listMachInfo.time.*Invalid input/i)
+		expect(String(caughtError)).toMatch(/Unable to parse MOS reply.*listMachInfo.time.*Invalid input/i)
 	})
 	test('requestMachineInfo - empty <time>', async () => {
 		// Prepare mock server response:
@@ -321,7 +321,7 @@ describe('Profile 0', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*listMachInfo.time.*Invalid input/i)
+		expect(String(caughtError)).toMatch(/Unable to parse MOS reply.*listMachInfo.time.*Invalid input/i)
 	})
 	test('requestMachineInfo - bad formatted <time>', async () => {
 		// Prepare mock server response:
@@ -340,6 +340,6 @@ describe('Profile 0', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*listMachInfo.time.*Invalid timestamp/i)
+		expect(String(caughtError)).toMatch(/Unable to parse MOS reply.*listMachInfo.time.*Invalid timestamp/i)
 	})
 })

--- a/packages/connector/src/__tests__/Profile0.spec.ts
+++ b/packages/connector/src/__tests__/Profile0.spec.ts
@@ -123,6 +123,8 @@ describe('Profile 0', () => {
 
 		expect(msg).toMatch(/<heartbeat/)
 		expect(msg).toMatch('<messageID>' + sendMessageId)
+
+		serverSocketMockLower.setAutoReplyToHeartBeat(true) // reset
 	})
 	test('send heartbeats', async () => {
 		socketMockLower.setAutoReplyToHeartBeat(false) // Handle heartbeat manually
@@ -156,6 +158,9 @@ describe('Profile 0', () => {
 		expect(heartbeatCount.upper).toBeGreaterThanOrEqual(4)
 		expect(heartbeatCount.lower).toBeGreaterThanOrEqual(4)
 		expect(mosDevice.getConnectionStatus()).toMatchObject({ PrimaryConnected: true })
+
+		socketMockLower.setAutoReplyToHeartBeat(true) // reset
+		socketMockUpper.setAutoReplyToHeartBeat(true) // reset
 	})
 
 	test('unknown party connects', async () => {
@@ -278,7 +283,7 @@ describe('Profile 0', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid timestamp/i)
+		expect(String(caughtError)).toMatch(/error when parsing reply.*listMachInfo.opTime.*Invalid timestamp/i)
 	})
 	test('requestMachineInfo - missing <time>', async () => {
 		// Prepare mock server response:
@@ -297,7 +302,7 @@ describe('Profile 0', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid input/i)
+		expect(String(caughtError)).toMatch(/error when parsing reply.*listMachInfo.time.*Invalid input/i)
 	})
 	test('requestMachineInfo - empty <time>', async () => {
 		// Prepare mock server response:
@@ -316,7 +321,7 @@ describe('Profile 0', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid input/i)
+		expect(String(caughtError)).toMatch(/error when parsing reply.*listMachInfo.time.*Invalid input/i)
 	})
 	test('requestMachineInfo - bad formatted <time>', async () => {
 		// Prepare mock server response:
@@ -335,6 +340,6 @@ describe('Profile 0', () => {
 		})
 		expect(mockReply).toHaveBeenCalledTimes(1)
 
-		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid timestamp/i)
+		expect(String(caughtError)).toMatch(/error when parsing reply.*listMachInfo.time.*Invalid timestamp/i)
 	})
 })

--- a/packages/connector/src/__tests__/Profile0.spec.ts
+++ b/packages/connector/src/__tests__/Profile0.spec.ts
@@ -11,7 +11,6 @@ import {
 	getMosConnection,
 	getMosDevice,
 	getXMLReply,
-	mosTypes,
 	setupMocks,
 } from './lib'
 import { MosConnection, MosDevice, IMOSObject, IMOSListMachInfo } from '..'
@@ -212,30 +211,68 @@ describe('Profile 0', () => {
 		expect(msg).toMatch(/<reqMachInfo\/>/)
 		checkMessageSnapshot(msg)
 
-		expect(returnedMachineInfo).toMatchObject({
-			manufacturer: mosTypes.mosString128.create('RadioVision, Ltd.'),
-			model: mosTypes.mosString128.create('TCS6000'),
-			hwRev: mosTypes.mosString128.create(''),
-			swRev: mosTypes.mosString128.create('2.1.0.37'),
-			DOM: mosTypes.mosString128.create(''),
-			SN: mosTypes.mosString128.create('927748927'),
-			ID: mosTypes.mosString128.create('airchache.newscenter.com'),
-			time: mosTypes.mosTime.create('2009-04-11T17:20:42'),
-			opTime: mosTypes.mosTime.create('2009-03-01T23:55:10'),
-			mosRev: mosTypes.mosString128.create('2.8.2'),
-
-			supportedProfiles: {
-				deviceType: 'NCS',
-				profile0: true,
-				profile1: true,
-				profile2: true,
-				profile3: true,
-				profile4: true,
-				profile5: true,
-				profile6: true,
-				profile7: true,
-			},
-		} as IMOSListMachInfo)
+		expect(returnedMachineInfo).toMatchObject(xmlApiData.machineInfoReply)
 		expect(returnedMachineInfo).toMatchSnapshot()
+	})
+	test('requestMachineInfo - opTime missing', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const replyMessage = xmlData.machineInfo.replace(/<opTime>.*<\/opTime>/, '')
+			const repl = getXMLReply(getMessageId(str), replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		const returnedMachineInfo: IMOSListMachInfo = await mosDevice.requestMachineInfo()
+		expect(mockReply).toHaveBeenCalledTimes(1)
+		const msg = decode(mockReply.mock.calls[0][0])
+		expect(msg).toMatch(/<reqMachInfo\/>/)
+		checkMessageSnapshot(msg)
+
+		const replyMessage = { ...xmlApiData.machineInfoReply }
+		replyMessage.opTime = undefined
+
+		expect(returnedMachineInfo).toMatchObject(replyMessage)
+		expect(returnedMachineInfo.opTime).toBeUndefined()
+	})
+	test('requestMachineInfo - empty <time>', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const replyMessage = xmlData.machineInfo.replace(/<time>.*<\/time>/, '<time></time>')
+			const repl = getXMLReply(getMessageId(str), replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		let caughtError: Error | undefined = undefined
+		await mosDevice.requestMachineInfo().catch((err) => {
+			caughtError = err
+		})
+		expect(mockReply).toHaveBeenCalledTimes(1)
+
+		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid input/i)
+	})
+	test('requestMachineInfo - bad formatted <time>', async () => {
+		// Prepare mock server response:
+		const mockReply = jest.fn((data) => {
+			const str = decode(data)
+			const replyMessage = xmlData.machineInfo.replace(/<time>.*<\/time>/, '<time>BAD DATA</time>')
+			const repl = getXMLReply(getMessageId(str), replyMessage)
+			return encode(repl)
+		})
+		socketMockLower.mockAddReply(mockReply)
+		if (!xmlApiData.mosObj.ID) throw new Error('xmlApiData.mosObj.ID not set')
+
+		let caughtError: Error | undefined = undefined
+		await mosDevice.requestMachineInfo().catch((err) => {
+			caughtError = err
+		})
+		expect(mockReply).toHaveBeenCalledTimes(1)
+
+		expect(String(caughtError)).toMatch(/error when parsing reply.*Invalid timestamp/i)
 	})
 })

--- a/packages/connector/src/__tests__/Profile1.spec.ts
+++ b/packages/connector/src/__tests__/Profile1.spec.ts
@@ -290,7 +290,7 @@ describe('Profile 1', () => {
 						const messageID = getMessageId(str)
 						const repl = getXMLReply(messageID, xmlData.mosListAll)
 						resolve(encode(repl))
-					}, DEFAULT_TIMEOUT + 500)
+					}, DEFAULT_TIMEOUT + 1000)
 				})
 			})
 			socketMockLower.mockAddReply(mockReply)
@@ -305,6 +305,6 @@ describe('Profile 1', () => {
 			expect(error).toMatch(/Sent command timed out after \d+ ms/)
 			expect(mockReply).toHaveBeenCalledTimes(1)
 		},
-		DEFAULT_TIMEOUT + 1000
+		DEFAULT_TIMEOUT + 2000
 	)
 })

--- a/packages/connector/src/__tests__/Profile1.spec.ts
+++ b/packages/connector/src/__tests__/Profile1.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import {
+	DEFAULT_TIMEOUT,
 	checkMessageSnapshot,
 	clearMocks,
 	decode,
@@ -277,29 +278,33 @@ describe('Profile 1', () => {
 		expect(returnedObjs).toMatchSnapshot()
 	})
 
-	test('command timeout', async () => {
-		expect(socketMockLower).toBeTruthy()
-		// Prepare mock server response:
-		const mockReply = jest.fn(async (data) => {
-			return new Promise<Buffer>((resolve) => {
-				setTimeout(() => {
-					const str = decode(data)
-					const messageID = getMessageId(str)
-					const repl = getXMLReply(messageID, xmlData.mosListAll)
-					resolve(encode(repl))
-				}, 500)
+	test(
+		'command timeout',
+		async () => {
+			expect(socketMockLower).toBeTruthy()
+			// Prepare mock server response:
+			const mockReply = jest.fn(async (data) => {
+				return new Promise<Buffer>((resolve) => {
+					setTimeout(() => {
+						const str = decode(data)
+						const messageID = getMessageId(str)
+						const repl = getXMLReply(messageID, xmlData.mosListAll)
+						resolve(encode(repl))
+					}, DEFAULT_TIMEOUT + 500)
+				})
 			})
-		})
-		socketMockLower.mockAddReply(mockReply)
+			socketMockLower.mockAddReply(mockReply)
 
-		let error
-		try {
-			await mosDevice.sendRequestAllMOSObjects()
-		} catch (e) {
-			error = `${e}`
-		}
+			let error = undefined
+			try {
+				await mosDevice.sendRequestAllMOSObjects()
+			} catch (e) {
+				error = `${e}`
+			}
 
-		expect(error).toMatch(/Sent command timed out after \d+ ms/)
-		expect(mockReply).toHaveBeenCalledTimes(1)
-	}, 500)
+			expect(error).toMatch(/Sent command timed out after \d+ ms/)
+			expect(mockReply).toHaveBeenCalledTimes(1)
+		},
+		DEFAULT_TIMEOUT + 1000
+	)
 })

--- a/packages/connector/src/__tests__/Profile2.spec.ts
+++ b/packages/connector/src/__tests__/Profile2.spec.ts
@@ -415,7 +415,7 @@ describe('Profile 2', () => {
 			error = e
 		}
 		expect(error).toBeTruthy()
-		expect(`${error}`).toMatch(/Reply from NRCS.*rundown not under MOS control/)
+		expect(`${error}`).toMatch(/Reply.*rundown not under MOS control/)
 	})
 	test('onMetadataReplace', async () => {
 		// Fake incoming message on socket:

--- a/packages/connector/src/__tests__/__snapshots__/Profile0-non-strict.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile0-non-strict.spec.ts.snap
@@ -1,6 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Profile 0 - non strict requestMachineInfo - empty <opTime> 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <reqMachInfo/>
+</mos>"
+`;
+
 exports[`Profile 0 - non strict requestMachineInfo - empty <time> 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <reqMachInfo/>
+</mos>"
+`;
+
+exports[`Profile 0 - non strict requestMachineInfo - missing <opTime> 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <reqMachInfo/>
+</mos>"
+`;
+
+exports[`Profile 0 - non strict requestMachineInfo - missing <time> 1`] = `
 "<mos>
   <ncsID>their.mos.id</ncsID>
   <mosID>our.mos.id</mosID>

--- a/packages/connector/src/__tests__/__snapshots__/Profile0-non-strict.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile0-non-strict.spec.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Profile 0 - non strict requestMachineInfo - empty <time> 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <reqMachInfo/>
+</mos>"
+`;

--- a/packages/connector/src/__tests__/__snapshots__/Profile0.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile0.spec.ts.snap
@@ -18,15 +18,6 @@ exports[`Profile 0 requestMachineInfo - missing <opTime> 1`] = `
 </mos>"
 `;
 
-exports[`Profile 0 requestMachineInfo - opTime missing 1`] = `
-"<mos>
-  <ncsID>their.mos.id</ncsID>
-  <mosID>our.mos.id</mosID>
-  <messageID>xx</messageID>
-  <reqMachInfo/>
-</mos>"
-`;
-
 exports[`Profile 0 requestMachineInfo 1`] = `
 "<mos>
   <ncsID>their.mos.id</ncsID>

--- a/packages/connector/src/__tests__/__snapshots__/Profile0.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile0.spec.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Profile 0 requestMachineInfo - opTime missing 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <reqMachInfo/>
+</mos>"
+`;
+
 exports[`Profile 0 requestMachineInfo 1`] = `
 "<mos>
   <ncsID>their.mos.id</ncsID>

--- a/packages/connector/src/__tests__/__snapshots__/Profile0.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile0.spec.ts.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Profile 0 requestMachineInfo - empty <opTime> 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <reqMachInfo/>
+</mos>"
+`;
+
+exports[`Profile 0 requestMachineInfo - missing <opTime> 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <reqMachInfo/>
+</mos>"
+`;
+
 exports[`Profile 0 requestMachineInfo - opTime missing 1`] = `
 "<mos>
   <ncsID>their.mos.id</ncsID>

--- a/packages/connector/src/__tests__/__snapshots__/Profile2.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile2.spec.ts.snap
@@ -986,9 +986,7 @@ exports[`Profile 2 onCreateRunningOrder with simple story 1`] = `
             "_mosString128": "3854737F:0003A34D:983A0B28",
           },
           "Items": [],
-          "Slug": {
-            "_mosString128": "undefined",
-          },
+          "Slug": undefined,
         },
       ],
     },
@@ -1339,9 +1337,7 @@ exports[`Profile 2 onROInsertStories - simple story 1`] = `
           "_mosString128": "17",
         },
         "Items": [],
-        "Slug": {
-          "_mosString128": "undefined",
-        },
+        "Slug": undefined,
       },
     ],
   ],
@@ -1676,9 +1672,7 @@ exports[`Profile 2 onROReplaceStories - simple story 1`] = `
           "_mosString128": "17",
         },
         "Items": [],
-        "Slug": {
-          "_mosString128": "undefined",
-        },
+        "Slug": undefined,
       },
     ],
   ],
@@ -2497,6 +2491,7 @@ exports[`Profile 2 sendCreateRunningOrder, sendReplaceRunningOrder 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2504,6 +2499,7 @@ exports[`Profile 2 sendCreateRunningOrder, sendReplaceRunningOrder 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2511,6 +2507,7 @@ exports[`Profile 2 sendCreateRunningOrder, sendReplaceRunningOrder 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2575,6 +2572,7 @@ exports[`Profile 2 sendCreateRunningOrder, sendReplaceRunningOrder 4`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2582,6 +2580,7 @@ exports[`Profile 2 sendCreateRunningOrder, sendReplaceRunningOrder 4`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2589,6 +2588,7 @@ exports[`Profile 2 sendCreateRunningOrder, sendReplaceRunningOrder 4`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2640,6 +2640,7 @@ exports[`Profile 2 sendDeleteRunningOrder 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2647,6 +2648,7 @@ exports[`Profile 2 sendDeleteRunningOrder 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2654,6 +2656,7 @@ exports[`Profile 2 sendDeleteRunningOrder 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2711,6 +2714,7 @@ exports[`Profile 2 sendItemStatus 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2718,6 +2722,7 @@ exports[`Profile 2 sendItemStatus 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2725,6 +2730,7 @@ exports[`Profile 2 sendItemStatus 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2797,6 +2803,7 @@ exports[`Profile 2 sendMetadataReplace 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2804,6 +2811,7 @@ exports[`Profile 2 sendMetadataReplace 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2811,6 +2819,7 @@ exports[`Profile 2 sendMetadataReplace 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2871,6 +2880,7 @@ exports[`Profile 2 sendRODeleteItems 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2878,6 +2888,7 @@ exports[`Profile 2 sendRODeleteItems 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2885,6 +2896,7 @@ exports[`Profile 2 sendRODeleteItems 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2942,6 +2954,7 @@ exports[`Profile 2 sendRODeleteStories 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2949,6 +2962,7 @@ exports[`Profile 2 sendRODeleteStories 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -2956,6 +2970,7 @@ exports[`Profile 2 sendRODeleteStories 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3025,6 +3040,7 @@ exports[`Profile 2 sendROInsertItems 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3032,6 +3048,7 @@ exports[`Profile 2 sendROInsertItems 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3039,6 +3056,7 @@ exports[`Profile 2 sendROInsertItems 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3105,6 +3123,7 @@ exports[`Profile 2 sendROInsertStories 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3112,6 +3131,7 @@ exports[`Profile 2 sendROInsertStories 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3119,6 +3139,7 @@ exports[`Profile 2 sendROInsertStories 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3180,6 +3201,7 @@ exports[`Profile 2 sendROMoveItems 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3187,6 +3209,7 @@ exports[`Profile 2 sendROMoveItems 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3194,6 +3217,7 @@ exports[`Profile 2 sendROMoveItems 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3254,6 +3278,7 @@ exports[`Profile 2 sendROMoveStories 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3261,6 +3286,7 @@ exports[`Profile 2 sendROMoveStories 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3268,6 +3294,7 @@ exports[`Profile 2 sendROMoveStories 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3337,6 +3364,7 @@ exports[`Profile 2 sendROReplaceItems 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3344,6 +3372,7 @@ exports[`Profile 2 sendROReplaceItems 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3351,6 +3380,7 @@ exports[`Profile 2 sendROReplaceItems 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3417,6 +3447,7 @@ exports[`Profile 2 sendROReplaceStories 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3424,6 +3455,7 @@ exports[`Profile 2 sendROReplaceStories 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3431,6 +3463,7 @@ exports[`Profile 2 sendROReplaceStories 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3489,6 +3522,7 @@ exports[`Profile 2 sendROSwapItems 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3496,6 +3530,7 @@ exports[`Profile 2 sendROSwapItems 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3503,6 +3538,7 @@ exports[`Profile 2 sendROSwapItems 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3558,6 +3594,7 @@ exports[`Profile 2 sendROSwapStories 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3565,6 +3602,7 @@ exports[`Profile 2 sendROSwapStories 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3572,6 +3610,7 @@ exports[`Profile 2 sendROSwapStories 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3624,6 +3663,7 @@ exports[`Profile 2 sendReadyToAir 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3631,6 +3671,7 @@ exports[`Profile 2 sendReadyToAir 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3638,6 +3679,7 @@ exports[`Profile 2 sendReadyToAir 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3811,6 +3853,7 @@ exports[`Profile 2 sendRunningOrderStatus 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3818,6 +3861,7 @@ exports[`Profile 2 sendRunningOrderStatus 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3825,6 +3869,7 @@ exports[`Profile 2 sendRunningOrderStatus 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3879,6 +3924,7 @@ exports[`Profile 2 sendStoryStatus 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3886,6 +3932,7 @@ exports[`Profile 2 sendStoryStatus 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -3893,6 +3940,7 @@ exports[`Profile 2 sendStoryStatus 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],

--- a/packages/connector/src/__tests__/__snapshots__/Profile3.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile3.spec.ts.snap
@@ -47,6 +47,7 @@ exports[`Profile 3 mosItemReplace 2`] = `
   "mosTypes": {
     "mosDuration": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -54,6 +55,7 @@ exports[`Profile 3 mosItemReplace 2`] = `
     },
     "mosString128": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -61,6 +63,7 @@ exports[`Profile 3 mosItemReplace 2`] = `
     },
     "mosTime": {
       "create": [Function],
+      "fallback": [Function],
       "is": [Function],
       "stringify": [Function],
       "validate": [Function],
@@ -607,19 +610,9 @@ exports[`Profile 3 onMosObjCreate 1`] = `
   [
     {
       "AirStatus": undefined,
-      "Changed": {
-        "_mosTime": 1609459200000,
-        "_timezone": "",
-        "_timezoneOffset": 0,
-      },
-      "ChangedBy": {
-        "_mosString128": "undefined",
-      },
-      "Created": {
-        "_mosTime": 1609459200000,
-        "_timezone": "",
-        "_timezoneOffset": 0,
-      },
+      "Changed": undefined,
+      "ChangedBy": undefined,
+      "Created": undefined,
       "CreatedBy": {
         "_mosString128": "Chris",
       },
@@ -675,7 +668,7 @@ exports[`Profile 3 onMosObjCreate 1`] = `
       "Duration": 1800,
       "Group": "Show 7",
       "ID": {
-        "_mosString128": "undefined",
+        "_mosString128": "",
       },
       "MosAbstract": undefined,
       "MosExternalMetaData": [
@@ -768,19 +761,9 @@ exports[`Profile 3 onMosReqObjectActionNew 1`] = `
   [
     {
       "AirStatus": undefined,
-      "Changed": {
-        "_mosTime": 1609459200000,
-        "_timezone": "",
-        "_timezoneOffset": 0,
-      },
-      "ChangedBy": {
-        "_mosString128": "undefined",
-      },
-      "Created": {
-        "_mosTime": 1609459200000,
-        "_timezone": "",
-        "_timezoneOffset": 0,
-      },
+      "Changed": undefined,
+      "ChangedBy": undefined,
+      "Created": undefined,
       "CreatedBy": {
         "_mosString128": "Chris",
       },
@@ -836,7 +819,7 @@ exports[`Profile 3 onMosReqObjectActionNew 1`] = `
       "Duration": 1800,
       "Group": "Show 7",
       "ID": {
-        "_mosString128": "undefined",
+        "_mosString128": "",
       },
       "MosAbstract": undefined,
       "MosExternalMetaData": [
@@ -898,19 +881,9 @@ exports[`Profile 3 onMosReqObjectActionUpdate 1`] = `
     "1EFA3009233F8329C1",
     {
       "AirStatus": undefined,
-      "Changed": {
-        "_mosTime": 1609459200000,
-        "_timezone": "",
-        "_timezoneOffset": 0,
-      },
-      "ChangedBy": {
-        "_mosString128": "undefined",
-      },
-      "Created": {
-        "_mosTime": 1609459200000,
-        "_timezone": "",
-        "_timezoneOffset": 0,
-      },
+      "Changed": undefined,
+      "ChangedBy": undefined,
+      "Created": undefined,
       "CreatedBy": {
         "_mosString128": "Chris",
       },

--- a/packages/connector/src/__tests__/__snapshots__/Profile4.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile4.spec.ts.snap
@@ -171,22 +171,10 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
             "MosObjects": [
               {
                 "AirStatus": undefined,
-                "Changed": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "ChangedBy": {
-                  "_mosString128": "undefined",
-                },
-                "Created": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "CreatedBy": {
-                  "_mosString128": "undefined",
-                },
+                "Changed": undefined,
+                "ChangedBy": undefined,
+                "Created": undefined,
+                "CreatedBy": undefined,
                 "Description": undefined,
                 "Duration": 0,
                 "Group": undefined,
@@ -231,7 +219,7 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
               },
             ],
             "ObjectID": {
-              "_mosString128": "undefined",
+              "_mosString128": "",
             },
             "Paths": [
               {
@@ -266,22 +254,10 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
             "MosObjects": [
               {
                 "AirStatus": undefined,
-                "Changed": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "ChangedBy": {
-                  "_mosString128": "undefined",
-                },
-                "Created": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "CreatedBy": {
-                  "_mosString128": "undefined",
-                },
+                "Changed": undefined,
+                "ChangedBy": undefined,
+                "Created": undefined,
+                "CreatedBy": undefined,
                 "Description": undefined,
                 "Duration": 0,
                 "Group": undefined,
@@ -326,7 +302,7 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
               },
             ],
             "ObjectID": {
-              "_mosString128": "undefined",
+              "_mosString128": "",
             },
             "Paths": [
               {
@@ -361,22 +337,10 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
             "MosObjects": [
               {
                 "AirStatus": undefined,
-                "Changed": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "ChangedBy": {
-                  "_mosString128": "undefined",
-                },
-                "Created": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "CreatedBy": {
-                  "_mosString128": "undefined",
-                },
+                "Changed": undefined,
+                "ChangedBy": undefined,
+                "Created": undefined,
+                "CreatedBy": undefined,
                 "Description": undefined,
                 "Duration": 0,
                 "Group": undefined,
@@ -421,7 +385,7 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
               },
             ],
             "ObjectID": {
-              "_mosString128": "undefined",
+              "_mosString128": "",
             },
             "Paths": [
               {
@@ -456,22 +420,10 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
             "MosObjects": [
               {
                 "AirStatus": undefined,
-                "Changed": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "ChangedBy": {
-                  "_mosString128": "undefined",
-                },
-                "Created": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "CreatedBy": {
-                  "_mosString128": "undefined",
-                },
+                "Changed": undefined,
+                "ChangedBy": undefined,
+                "Created": undefined,
+                "CreatedBy": undefined,
                 "Description": undefined,
                 "Duration": 0,
                 "Group": undefined,
@@ -516,7 +468,7 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
               },
             ],
             "ObjectID": {
-              "_mosString128": "undefined",
+              "_mosString128": "",
             },
             "Paths": [
               {
@@ -551,22 +503,10 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
             "MosObjects": [
               {
                 "AirStatus": undefined,
-                "Changed": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "ChangedBy": {
-                  "_mosString128": "undefined",
-                },
-                "Created": {
-                  "_mosTime": 1609459200000,
-                  "_timezone": "",
-                  "_timezoneOffset": 0,
-                },
-                "CreatedBy": {
-                  "_mosString128": "undefined",
-                },
+                "Changed": undefined,
+                "ChangedBy": undefined,
+                "Created": undefined,
+                "CreatedBy": undefined,
                 "Description": undefined,
                 "Duration": 0,
                 "Group": undefined,
@@ -611,7 +551,7 @@ exports[`Profile 4 onRunningOrderStory 1`] = `
               },
             ],
             "ObjectID": {
-              "_mosString128": "undefined",
+              "_mosString128": "",
             },
             "Paths": [
               {

--- a/packages/connector/src/__tests__/lib.ts
+++ b/packages/connector/src/__tests__/lib.ts
@@ -68,7 +68,7 @@ export async function getMosConnection(profiles: IProfiles, strict: boolean): Pr
 
 	return Promise.resolve(mos)
 }
-export const DEFAULT_TIMEOUT = 400
+export const DEFAULT_TIMEOUT = 600
 export async function getMosDevice(mos: MosConnection): Promise<MosDevice> {
 	SocketMock.mockClear()
 

--- a/packages/connector/src/__tests__/lib.ts
+++ b/packages/connector/src/__tests__/lib.ts
@@ -68,7 +68,7 @@ export async function getMosConnection(profiles: IProfiles, strict: boolean): Pr
 
 	return Promise.resolve(mos)
 }
-export const DEFAULT_TIMEOUT = 200
+export const DEFAULT_TIMEOUT = 400
 export async function getMosDevice(mos: MosConnection): Promise<MosDevice> {
 	SocketMock.mockClear()
 

--- a/packages/connector/src/connection/NCSServerConnection.ts
+++ b/packages/connector/src/connection/NCSServerConnection.ts
@@ -56,6 +56,9 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 		this._connected = false
 		this._debug = debug ?? false
 	}
+	get timeout(): number {
+		return this._timeout
+	}
 	/** Create a MOS client, which talks to  */
 	createClient(clientID: string, port: number, clientDescription: ConnectionType, useHeartbeats: boolean): void {
 		const client = new MosSocketClient(this._host, port, clientDescription, this._timeout, this._debug)

--- a/packages/helper/src/index.ts
+++ b/packages/helper/src/index.ts
@@ -9,3 +9,4 @@ export {
 } from './utils/Utils'
 export * as MosModel from './mosModel'
 export * from './stringify/stringifyMosObject'
+export * from './utils/Errors'

--- a/packages/helper/src/mosModel/__tests__/profile2.spec.ts
+++ b/packages/helper/src/mosModel/__tests__/profile2.spec.ts
@@ -37,7 +37,7 @@ describe('Profile 2', () => {
 			{
 				Type: IMOSObjectPathType.PATH,
 				Description: 'MPEG2 Video',
-				Target: '\\servermediaclip392028cd2320s0d.mxf',
+				Target: '\\server\\media\\clip392028cd2320s0d.mxf',
 			},
 			{
 				Type: IMOSObjectPathType.PROXY_PATH,
@@ -59,7 +59,7 @@ describe('Profile 2', () => {
 <itemEdDur>715</itemEdDur>
 <itemUserTimingDur>415</itemUserTimingDur>
 <objPaths>
-<objPath techDescription="MPEG2 Video">\\server\media\clip392028cd2320s0d.mxf</objPath>
+<objPath techDescription="MPEG2 Video">\\server\\media\\clip392028cd2320s0d.mxf</objPath>
 <objProxyPath techDescription="WM9 750Kbps">https://server/proxy/clipe.wmv</objProxyPath>
 <objMetadataPath techDescription="MOS Object">https://server/proxy/clipe.xml</objMetadataPath>
 </objPaths>

--- a/packages/helper/src/mosModel/lib.ts
+++ b/packages/helper/src/mosModel/lib.ts
@@ -27,3 +27,19 @@ export type AnyXML = { [key: string]: any }
 export function has(obj: unknown, property: string): boolean {
 	return Object.hasOwnProperty.call(obj, property)
 }
+export function getHandleError(basePath: string): <V, R>(func: (val: V) => R, value: V, path: string) => R {
+	const handleError = <V, R>(func: (val: V) => R, value: V, path: string): R => {
+		try {
+			return func(value)
+		} catch (org) {
+			// is Error?
+			const orgMessage = org instanceof Error ? org.message : `${org}`
+			const newPath = [basePath, path].filter(Boolean).join('.')
+			const error = new Error(`Error parsing "${newPath}": ${orgMessage}`)
+			if (org instanceof Error) error.stack = org.stack
+			throw error
+		}
+	}
+
+	return handleError
+}

--- a/packages/helper/src/mosModel/parseMosTypes.ts
+++ b/packages/helper/src/mosModel/parseMosTypes.ts
@@ -1,0 +1,80 @@
+import { MosTypes, getMosTypes, MosType } from '@mos-connection/model'
+
+export function getParseMosTypes(strict: boolean): MosParseTypes {
+	const mosTypes = getMosTypes(strict)
+
+	return {
+		strict: mosTypes.strict,
+		mosString128: wrapParseMethods(mosTypes.mosString128, strict),
+		mosDuration: wrapParseMethods(mosTypes.mosDuration, strict),
+		mosTime: wrapParseMethods(mosTypes.mosTime, strict),
+	}
+}
+type MosParseTypes = {
+	[key in keyof MosTypes]: MosTypes[key] extends MosType<infer Serialized, infer Value, infer CreateValue>
+		? MosTypeParse<Serialized, Value, CreateValue>
+		: MosTypes[key]
+}
+interface MosTypeParse<Serialized, Value, CreateValue> extends Omit<MosType<Serialized, Value, CreateValue>, 'create'> {
+	/**
+	 * Used to parse data that is optional.
+	 * If the data is missing, undefined is returned.
+	 */
+	createOptional: (anyValue: CreateValue) => Serialized | undefined
+	/**
+	 * Used to parse data that is required.
+	 * If in strict mode, the data must be present and parsable, otherwise an error is thrown.
+	 * If not in strict mode, a fallback value will be used.
+	 */
+	createRequired: (anyValue: CreateValue) => Serialized
+}
+
+function wrapParseMethods<Serialized, Value, CreateValue>(
+	mosType: MosType<Serialized, Value, CreateValue>,
+	strict: boolean
+): MosTypeParse<Serialized, Value, CreateValue> {
+	return {
+		createOptional: wrapParseMethodCreateOptional(mosType),
+		createRequired: wrapParseMethodCreateRequired(mosType, strict),
+		validate: mosType.validate,
+		valueOf: mosType.valueOf,
+		stringify: mosType.stringify,
+		is: mosType.is,
+	} as MosTypeParse<Serialized, Value, CreateValue>
+}
+function wrapParseMethodCreateOptional<Serialized, Value, CreateValue>(
+	mosType: MosType<Serialized, Value, CreateValue>
+): MosTypeParse<Serialized, Value, CreateValue>['createOptional'] {
+	return (value: any) => {
+		// handle empty string:
+		if (typeof value === 'string' && !value.trim()) value = undefined
+		// handle empty object (can happen when parsing an empty xml tag):
+		if (typeof value === 'object' && Object.keys(value).length === 0) value = undefined
+
+		if (value === undefined) return undefined
+		return mosType.create(value)
+	}
+}
+function wrapParseMethodCreateRequired<Serialized, Value, CreateValue>(
+	mosType: MosType<Serialized, Value, CreateValue>,
+	strict: boolean
+): MosTypeParse<Serialized, Value, CreateValue>['createRequired'] {
+	return (value: any) => {
+		// handle empty string:
+		if (typeof value === 'string' && !value.trim()) value = undefined
+		// handle empty object (can happen when parsing an empty xml tag):
+		if (typeof value === 'object' && Object.keys(value).length === 0) value = undefined
+
+		if (value === undefined) {
+			// Something might be wrong. value is undefined, but should not be (?)
+			if (strict) {
+				// This will throw if the mosType doesn't handle undefined:
+				return mosType.create(value)
+			} else {
+				return mosType.fallback()
+			}
+		} else {
+			return mosType.create(value)
+		}
+	}
+}

--- a/packages/helper/src/mosModel/profile0/heartBeat.ts
+++ b/packages/helper/src/mosModel/profile0/heartBeat.ts
@@ -10,7 +10,7 @@ export class HeartBeat extends MosMessage {
 	/** */
 	constructor(port: PortType, time: IMOSTime | undefined, strict: boolean) {
 		super(port, strict)
-		if (!time) time = getMosTypes(true).mosTime.create(undefined)
+		if (!time) time = getMosTypes(true).mosTime.create(Date.now())
 		this.time = time
 	}
 

--- a/packages/helper/src/mosModel/profile1/xmlConversion.ts
+++ b/packages/helper/src/mosModel/profile1/xmlConversion.ts
@@ -1,18 +1,19 @@
 import * as XMLBuilder from 'xmlbuilder'
-import { IMOSRequestObjectList, IMOSObject, IMOSAck, IMOSAckStatus, getMosTypes } from '@mos-connection/model'
+import { IMOSRequestObjectList, IMOSObject, IMOSAck, IMOSAckStatus } from '@mos-connection/model'
 import { XMLObjectPaths, XMLMosExternalMetaData } from '../profile2/xmlConversion'
 import { AnyXML, has } from '../lib'
 import { addTextElementInternal } from '../../utils/Utils'
+import { getParseMosTypes } from '../parseMosTypes'
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace XMLMosAck {
 	export function fromXML(xml: AnyXML, strict: boolean): IMOSAck {
-		const mosTypes = getMosTypes(strict)
+		const mosTypes = getParseMosTypes(strict)
 		const ack: IMOSAck = {
-			ID: mosTypes.mosString128.create(xml.objID),
+			ID: mosTypes.mosString128.createRequired(xml.objID),
 			Revision: typeof xml.objRev === 'number' ? xml.objRev : 0,
 			Status: typeof xml.status === 'string' ? (xml.status as IMOSAckStatus) : IMOSAckStatus.ACK,
-			Description: mosTypes.mosString128.create(
+			Description: mosTypes.mosString128.createRequired(
 				typeof xml.statusDescription === 'string' ? xml.statusDescription : ''
 			),
 		}
@@ -41,10 +42,10 @@ export namespace XMLMosObjects {
 }
 export namespace XMLMosObject {
 	export function fromXML(xml: AnyXML, strict: boolean): IMOSObject {
-		const mosTypes = getMosTypes(strict)
+		const mosTypes = getParseMosTypes(strict)
 		const mosObj: IMOSObject = {
-			ID: mosTypes.mosString128.create(xml.objID),
-			Slug: mosTypes.mosString128.create(xml.objSlug),
+			ID: mosTypes.mosString128.createRequired(xml.objID),
+			Slug: mosTypes.mosString128.createRequired(xml.objSlug),
 			MosAbstract: xml.mosAbstract,
 			Group: xml.objGroup,
 			Type: xml.objType,
@@ -54,16 +55,16 @@ export namespace XMLMosObject {
 			Status: xml.status,
 			AirStatus: xml.objAir,
 			Paths: XMLObjectPaths.fromXML(xml.objPaths),
-			CreatedBy: mosTypes.mosString128.create(xml.createdBy),
-			Created: mosTypes.mosTime.create(xml.created),
-			ChangedBy: mosTypes.mosString128.create(xml.changedBy),
-			Changed: mosTypes.mosTime.create(xml.changed),
+			CreatedBy: mosTypes.mosString128.createOptional(xml.createdBy),
+			Created: mosTypes.mosTime.createOptional(xml.created),
+			ChangedBy: mosTypes.mosString128.createOptional(xml.changedBy),
+			Changed: mosTypes.mosTime.createOptional(xml.changed),
 			Description: xml.description,
 		}
 		if (has(xml, 'mosExternalMetadata'))
 			mosObj.MosExternalMetaData = XMLMosExternalMetaData.fromXML(xml.mosExternalMetadata)
 		if (has(xml, 'mosItemEditorProgID'))
-			mosObj.MosItemEditorProgID = mosTypes.mosString128.create(xml.mosItemEditorProgID)
+			mosObj.MosItemEditorProgID = mosTypes.mosString128.createOptional(xml.mosItemEditorProgID)
 		return mosObj
 	}
 	export function toXML(xml: XMLBuilder.XMLElement, obj: IMOSObject, strict: boolean): void {

--- a/packages/helper/src/mosModel/profile2/roElementStat.ts
+++ b/packages/helper/src/mosModel/profile2/roElementStat.ts
@@ -24,7 +24,7 @@ export class ROElementStat extends MosMessage {
 	constructor(options: ROElementStatOptions, strict: boolean) {
 		super('upper', strict)
 		this.options = options
-		this.time = getMosTypes(strict).mosTime.create(undefined)
+		this.time = getMosTypes(strict).mosTime.create(Date.now())
 	}
 
 	/** */

--- a/packages/helper/src/mosModel/profile2/xmlConversion.ts
+++ b/packages/helper/src/mosModel/profile2/xmlConversion.ts
@@ -11,22 +11,22 @@ import {
 	IMOSROAckStory,
 	IMOSROAckItem,
 	IMOSROAckObject,
-	getMosTypes,
 } from '@mos-connection/model'
 import { AnyXML, has, isEmpty, numberOrUndefined } from '../lib'
 import { ROAck } from './ROAck'
 import { XMLMosObjects } from '../profile1/xmlConversion'
 import { addTextElementInternal } from '../../utils/Utils'
+import { getParseMosTypes } from '../parseMosTypes'
 /* eslint-disable @typescript-eslint/no-namespace */
 
 export namespace XMLMosROAck {
 	export function fromXML(xml: AnyXML, strict: boolean): ROAck {
-		const mosTypes = getMosTypes(strict)
+		const mosTypes = getParseMosTypes(strict)
 
 		const roAck: ROAck = new ROAck(
 			{
-				ID: mosTypes.mosString128.create(xml.roID),
-				Status: mosTypes.mosString128.create(xml.roStatus),
+				ID: mosTypes.mosString128.createRequired(xml.roID),
+				Status: mosTypes.mosString128.createRequired(xml.roStatus),
 				Stories: [],
 			},
 			strict
@@ -52,15 +52,15 @@ export namespace XMLMosROAck {
 		for (let i = 0; i < iMax; i++) {
 			if (xmlStoryIDs[i]) {
 				story = {
-					ID: mosTypes.mosString128.create(xmlStoryIDs[i]),
+					ID: mosTypes.mosString128.createRequired(xmlStoryIDs[i]),
 					Items: [],
 				}
 				roAck.Stories.push(story)
 			}
 			if (xmlItemIDs[i]) {
 				item = {
-					ID: mosTypes.mosString128.create(xmlStoryIDs[i]),
-					Channel: mosTypes.mosString128.create(''),
+					ID: mosTypes.mosString128.createRequired(xmlStoryIDs[i]),
+					Channel: mosTypes.mosString128.createRequired(''),
 					Objects: [],
 				}
 				if (story) story.Items.push(item)
@@ -79,20 +79,23 @@ export namespace XMLMosROAck {
 }
 export namespace XMLRunningOrderBase {
 	export function fromXML(xml: AnyXML, strict: boolean): IMOSRunningOrderBase {
-		const mosTypes = getMosTypes(strict)
+		const mosTypes = getParseMosTypes(strict)
 		const ro: IMOSRunningOrderBase = {
-			ID: mosTypes.mosString128.create(xml.roID),
-			Slug: mosTypes.mosString128.create(xml.roSlug),
+			ID: mosTypes.mosString128.createRequired(xml.roID),
+			Slug: mosTypes.mosString128.createRequired(xml.roSlug),
 		}
 
-		if (has(xml, 'roEdStart') && !isEmpty(xml.roEdStart)) ro.EditorialStart = mosTypes.mosTime.create(xml.roEdStart)
+		if (has(xml, 'roEdStart') && !isEmpty(xml.roEdStart))
+			ro.EditorialStart = mosTypes.mosTime.createOptional(xml.roEdStart)
 		if (has(xml, 'roEdDur') && !isEmpty(xml.roEdDur))
-			ro.EditorialDuration = mosTypes.mosDuration.create(xml.roEdDur)
+			ro.EditorialDuration = mosTypes.mosDuration.createOptional(xml.roEdDur)
 		if (has(xml, 'roChannel') && !isEmpty(xml.roChannel))
-			ro.DefaultChannel = mosTypes.mosString128.create(xml.roChannel)
-		if (has(xml, 'roTrigger') && !isEmpty(xml.roTrigger)) ro.Trigger = mosTypes.mosString128.create(xml.roTrigger)
-		if (has(xml, 'macroIn') && !isEmpty(xml.macroIn)) ro.MacroIn = mosTypes.mosString128.create(xml.macroIn)
-		if (has(xml, 'macroOut') && !isEmpty(xml.macroOut)) ro.MacroOut = mosTypes.mosString128.create(xml.macroOut)
+			ro.DefaultChannel = mosTypes.mosString128.createOptional(xml.roChannel)
+		if (has(xml, 'roTrigger') && !isEmpty(xml.roTrigger))
+			ro.Trigger = mosTypes.mosString128.createOptional(xml.roTrigger)
+		if (has(xml, 'macroIn') && !isEmpty(xml.macroIn)) ro.MacroIn = mosTypes.mosString128.createOptional(xml.macroIn)
+		if (has(xml, 'macroOut') && !isEmpty(xml.macroOut))
+			ro.MacroOut = mosTypes.mosString128.createOptional(xml.macroOut)
 		if (has(xml, 'mosExternalMetadata') && !isEmpty(xml.mosExternalMetadata)) {
 			// TODO: Handle an array of mosExternalMetadata
 			const meta: IMOSExternalMetaData = {
@@ -151,10 +154,10 @@ export namespace XMLROStoryBase {
 }
 export namespace XMLROStory {
 	export function fromXML(xml: AnyXML, strict: boolean): IMOSROStory {
-		const mosTypes = getMosTypes(strict)
+		const mosTypes = getParseMosTypes(strict)
 		const story: IMOSROStory = {
-			ID: mosTypes.mosString128.create(xml.storyID),
-			Slug: mosTypes.mosString128.create(xml.storySlug),
+			ID: mosTypes.mosString128.createRequired(xml.storyID),
+			Slug: mosTypes.mosString128.createOptional(xml.storySlug),
 			Items: [],
 			// TODO: Add & test Number, ObjectID, MOSID, mosAbstract, Paths
 			// Channel, EditorialStart, EditorialDuration, UserTimingDuration, Trigger, MacroIn, MacroOut, MosExternalMetaData
@@ -172,7 +175,7 @@ export namespace XMLROStory {
 			story.MosExternalMetaData = XMLMosExternalMetaData.fromXML(xml.mosExternalMetadata)
 
 		if (has(xml, 'storyNum') && !isEmpty(xml.storyNum))
-			story.Number = mosTypes.mosString128.create(xml.storyNum || '')
+			story.Number = mosTypes.mosString128.createOptional(xml.storyNum || '')
 
 		return story
 	}
@@ -197,10 +200,10 @@ export namespace XMLMosItems {
 }
 export namespace XMLMosItem {
 	export function fromXML(xml: AnyXML, strict: boolean): IMOSItem {
-		const mosTypes = getMosTypes(strict)
+		const mosTypes = getParseMosTypes(strict)
 		const item: IMOSItem = {
-			ID: mosTypes.mosString128.create(xml.itemID),
-			ObjectID: mosTypes.mosString128.create(xml.objID),
+			ID: mosTypes.mosString128.createRequired(xml.itemID),
+			ObjectID: mosTypes.mosString128.createRequired(xml.objID),
 			MOSID: xml.mosID,
 			// TODO: mosAbstract?: string,
 			// TODO: Channel?: MosString128,
@@ -208,7 +211,8 @@ export namespace XMLMosItem {
 			// TODO: MacroOut?: MosString128,
 		}
 
-		if (has(xml, 'itemSlug') && !isEmpty(xml.itemSlug)) item.Slug = mosTypes.mosString128.create(xml.itemSlug)
+		if (has(xml, 'itemSlug') && !isEmpty(xml.itemSlug))
+			item.Slug = mosTypes.mosString128.createOptional(xml.itemSlug)
 		if (has(xml, 'objPaths')) item.Paths = XMLObjectPaths.fromXML(xml.objPaths)
 		if (has(xml, 'itemEdStart')) item.EditorialStart = numberOrUndefined(xml.itemEdStart)
 		if (has(xml, 'itemEdDur')) item.EditorialDuration = numberOrUndefined(xml.itemEdDur)
@@ -217,13 +221,13 @@ export namespace XMLMosItem {
 		if (has(xml, 'mosExternalMetadata'))
 			item.MosExternalMetaData = XMLMosExternalMetaData.fromXML(xml.mosExternalMetadata)
 		if (has(xml, 'mosAbstract')) item.mosAbstract = xml.mosAbstract + ''
-		if (has(xml, 'objSlug')) item.ObjectSlug = getMosTypes(false).mosString128.create(xml.objSlug) // temporary fix for long slugs
-		if (has(xml, 'itemChannel')) item.Channel = mosTypes.mosString128.create(xml.itemChannel)
+		if (has(xml, 'objSlug')) item.ObjectSlug = getParseMosTypes(false).mosString128.createOptional(xml.objSlug) // temporary fix for long slugs
+		if (has(xml, 'itemChannel')) item.Channel = mosTypes.mosString128.createOptional(xml.itemChannel)
 		if (has(xml, 'objDur')) item.Duration = numberOrUndefined(xml.objDur)
 		if (has(xml, 'objTB')) item.TimeBase = numberOrUndefined(xml.objTB)
 
-		if (has(xml, 'macroIn')) item.MacroIn = mosTypes.mosString128.create(xml.macroIn)
-		if (has(xml, 'macroOut')) item.MacroOut = mosTypes.mosString128.create(xml.macroOut)
+		if (has(xml, 'macroIn')) item.MacroIn = mosTypes.mosString128.createOptional(xml.macroIn)
+		if (has(xml, 'macroOut')) item.MacroOut = mosTypes.mosString128.createOptional(xml.macroOut)
 
 		if (has(xml, 'mosObj')) {
 			// Note: the <mosObj> is sent in roStorySend

--- a/packages/helper/src/utils/Errors.ts
+++ b/packages/helper/src/utils/Errors.ts
@@ -1,0 +1,10 @@
+/** An error that occurred while parsing a reply to a sent mos message */
+export class MosReplyError extends Error {
+	constructor(orgError: unknown, public readonly parsedReply: unknown | undefined) {
+		super('N/A')
+		this.name = 'MosReplyError'
+		const orgMessage = orgError instanceof Error ? orgError.message : `${orgError}`
+		if (orgError instanceof Error) this.stack = orgError.stack
+		this.message = `Unable to parse MOS reply: ${orgMessage}`
+	}
+}

--- a/packages/model/src/mosTypes.ts
+++ b/packages/model/src/mosTypes.ts
@@ -50,17 +50,20 @@ export function stringifyMosType(
 	return { isMosType: false }
 }
 
-interface MosType<Serialized, Value, CreateValue> {
+export interface MosType<Serialized, Value, CreateValue> {
 	/** Creates a MosType using provided data. The MosType is then used in data sent into MOS-connection  */
 	create: (anyValue: CreateValue) => Serialized
 	/** (internal function) Validate the data. Throws if something is wrong with the data */
 	validate: (value: Serialized) => void
 	/** Returns the value of the MosType */
-	valueOf(value: Serialized): Value
+	valueOf: (value: Serialized) => Value
 	/** Returns a stringified representation of the MosType */
-	stringify(value: Serialized): string
+	stringify: (value: Serialized) => string
 	/** Returns true if the provided data is of this MosType */
-	is(value: Serialized | any): value is Serialized
+	is: (value: Serialized | any) => value is Serialized
+
+	/** Returns a fallback value, used to replace missing or non-parsable data in non-strict mode */
+	fallback: () => Serialized
 }
 
 interface InternalMosType<Serialized, Value> {
@@ -69,6 +72,7 @@ interface InternalMosType<Serialized, Value> {
 	valueOf(value: Serialized): Value
 	stringify(value: Serialized): string
 	is(value: Serialized | any): value is Serialized
+	fallback(): Serialized
 }
 function getMosType<Serialized, Value, CreateValue>(
 	mosType: InternalMosType<Serialized, Value>,
@@ -80,6 +84,7 @@ function getMosType<Serialized, Value, CreateValue>(
 		stringify: (value: Serialized): string => mosType.stringify(value),
 		valueOf: (value: Serialized): Value => mosType.valueOf(value),
 		is: (value: Serialized): value is Serialized => mosType.is(value),
+		fallback: (): Serialized => mosType.fallback(),
 	}
 }
 

--- a/packages/model/src/mosTypes/__tests__/mosDuration.spec.ts
+++ b/packages/model/src/mosTypes/__tests__/mosDuration.spec.ts
@@ -11,7 +11,6 @@ describe('MosDuration', () => {
 		expect(() => mosTypes.mosDuration.create('asdf')).toThrowError(/Invalid input/)
 		expect(() => mosTypes.mosDuration.create('1:23:xx')).toThrowError(/Invalid input/)
 		expect(() => mosTypes.mosDuration.create('0:00:00')).not.toThrowError()
-		// @ts-expect-error bad input:
 		expect(() => mosTypes.mosDuration.create([])).toThrowError(/Invalid input/)
 
 		// @ts-expect-error wrong input, but still:

--- a/packages/model/src/mosTypes/__tests__/mosTime.spec.ts
+++ b/packages/model/src/mosTypes/__tests__/mosTime.spec.ts
@@ -68,7 +68,7 @@ describe('MosTime', () => {
 		expect(toTime(date.toString())).toBe(date.getTime()) // locale time
 		expect(toTime(date.toUTCString())).toBe(date.getTime()) // utc
 		expect(toTime(123456789)).toBe(123456789)
-		expect(Math.abs(toTime(undefined) - new Date().getTime())).toBeLessThan(10)
+		expect(Math.abs(toTime(Date.now()) - new Date().getTime())).toBeLessThan(10)
 
 		expect(mosTypes.mosTime.valueOf(mosTypes.mosTime.create(mosTypes.mosTime.create(date)))).toBe(date.getTime())
 
@@ -84,11 +84,7 @@ describe('MosTime', () => {
 		expect(toTime('2009-04-11T14:22:07+5:00')).toBe(new Date('2009-04-11T14:22:07+05:00').getTime())
 		expect(toTime('2009-04-11T14:22:07+5:30')).toBe(new Date('2009-04-11T14:22:07+05:30').getTime())
 		expect(toTime('2009-04-11T14:22:07+5:5')).toBe(new Date('2009-04-11T14:22:07+05:05').getTime())
-
 		expect(toTime('Sun Feb 25 2018 08:59:08 GMT+0100 (CET)')).toBe(new Date('2018-02-25T08:59:08+01:00').getTime())
-
-		// Empty string
-		expect(typeof toTime('')).toBe('number')
 	})
 	test('format time strings correctly', () => {
 		const mosTypes = getMosTypes(true)

--- a/packages/model/src/mosTypes/mosDuration.ts
+++ b/packages/model/src/mosTypes/mosDuration.ts
@@ -28,7 +28,7 @@ export function create(anyValue: AnyValue, strict: boolean): IMOSDuration {
 	validate(mosDuration, strict)
 	return mosDuration
 }
-export type AnyValue = string | number
+export type AnyValue = string | number | any
 export function validate(_mosDuration: IMOSDuration, _strict: boolean): void {
 	// nothing
 }
@@ -54,4 +54,9 @@ export function is(mosDuration: IMOSDuration | any): mosDuration is IMOSDuration
 	if (typeof mosDuration !== 'object') return false
 	if (mosDuration === null) return false
 	return (mosDuration as IMOSDuration)._mosDuration !== undefined
+}
+export function fallback(): IMOSDuration {
+	const mosDuration: IMOSDuration = { _mosDuration: 0 } as IMOSDuration
+	validate(mosDuration, true)
+	return mosDuration
 }

--- a/packages/model/src/mosTypes/mosString128.ts
+++ b/packages/model/src/mosTypes/mosString128.ts
@@ -17,6 +17,8 @@ export function create(anyValue: AnyValue, strict: boolean): IMOSString128 {
 		} else {
 			strValue = JSON.stringify(anyValue)
 		}
+	} else if (anyValue === undefined) {
+		strValue = ''
 	} else {
 		strValue = anyValue !== `undefined` ? String(anyValue) : ''
 	}
@@ -47,4 +49,9 @@ export function is(mosString128: IMOSString128 | any): mosString128 is IMOSStrin
 	if (typeof mosString128 !== 'object') return false
 	if (mosString128 === null) return false
 	return (mosString128 as IMOSString128)._mosString128 !== undefined
+}
+export function fallback(): IMOSString128 {
+	const mosString: IMOSString128 = { _mosString128: '' } as IMOSString128
+	validate(mosString, true)
+	return mosString
 }

--- a/packages/model/src/mosTypes/mosTime.ts
+++ b/packages/model/src/mosTypes/mosTime.ts
@@ -117,6 +117,15 @@ export function is(mosTime: IMOSTime | any): mosTime is IMOSTime {
 		(mosTime as IMOSTime)._timezoneOffset !== undefined
 	)
 }
+export function fallback(): IMOSTime {
+	const iMosTime: IMOSTime = {
+		_mosTime: 0,
+		_timezone: '',
+		_timezoneOffset: 0,
+	} as IMOSTime
+	validate(iMosTime, true)
+	return iMosTime
+}
 
 function parseTimeOffset(timestamp: string): false | { timeOffsetValue: number; timezoneDeclaration: string } {
 	let timeOffsetValue: number

--- a/packages/model/src/mosTypes/mosTime.ts
+++ b/packages/model/src/mosTypes/mosTime.ts
@@ -20,41 +20,36 @@ export function create(timestamp: AnyValue, strict: boolean): IMOSTime {
 		if (typeof timestamp === 'number') {
 			time = new Date(timestamp)
 		} else if (typeof timestamp === 'string') {
-			if (timestamp.trim()) {
-				// formats:
-				// YYYY-MM-DD'T'hh:mm:ss[,ddd]['Z']
-				// Sun Feb 25 2018 08:59:08 GMT+0100 (CET)
-				// 2018-02-25T08:00:45.528Z
+			// formats:
+			// YYYY-MM-DD'T'hh:mm:ss[,ddd]['Z']
+			// Sun Feb 25 2018 08:59:08 GMT+0100 (CET)
+			// 2018-02-25T08:00:45.528Z
 
-				let _timezoneZuluIndicator = ''
-				let _timezoneDeclaration = ''
+			let _timezoneZuluIndicator = ''
+			let _timezoneDeclaration = ''
 
-				// parse out custom Z indicator (mos-centric)
-				const customFormatParseResult = parseMosCustomFormat(timestamp)
-				// parse out custom timezones (mos local-local centric format)
-				const timezoneParseResult = parseTimeOffset(timestamp)
+			// parse out custom Z indicator (mos-centric)
+			const customFormatParseResult = parseMosCustomFormat(timestamp)
+			// parse out custom timezones (mos local-local centric format)
+			const timezoneParseResult = parseTimeOffset(timestamp)
 
-				if (customFormatParseResult !== false) {
-					_timezone = customFormatParseResult.timezoneIndicator
-					_timezoneOffset = customFormatParseResult.timezoneOffset
-					_timezoneZuluIndicator = customFormatParseResult.timezoneIndicator
+			if (customFormatParseResult !== false) {
+				_timezone = customFormatParseResult.timezoneIndicator
+				_timezoneOffset = customFormatParseResult.timezoneOffset
+				_timezoneZuluIndicator = customFormatParseResult.timezoneIndicator
 
-					const r = customFormatParseResult
-					const dateStr = `${r.yy}-${r.mm}-${r.dd}T${r.hh}:${r.ii}:${r.ss}${
-						r.ms ? '.' + r.ms : ''
-					}${_timezoneZuluIndicator}${_timezoneDeclaration}`
-					time = new Date(dateStr)
-				} else if (timezoneParseResult !== false) {
-					_timezoneDeclaration = timezoneParseResult.timezoneDeclaration
+				const r = customFormatParseResult
+				const dateStr = `${r.yy}-${r.mm}-${r.dd}T${r.hh}:${r.ii}:${r.ss}${
+					r.ms ? '.' + r.ms : ''
+				}${_timezoneZuluIndicator}${_timezoneDeclaration}`
+				time = new Date(dateStr)
+			} else if (timezoneParseResult !== false) {
+				_timezoneDeclaration = timezoneParseResult.timezoneDeclaration
 
-					time = new Date(timestamp)
-				} else {
-					// try to parse the time directly with Date, for Date-supported formats
-					time = new Date(timestamp)
-				}
+				time = new Date(timestamp)
 			} else {
-				// empty string, create Date now:
-				time = new Date()
+				// try to parse the time directly with Date, for Date-supported formats
+				time = new Date(timestamp)
 			}
 		} else if (typeof timestamp === 'object') {
 			if (timestamp instanceof Date) {
@@ -68,8 +63,7 @@ export function create(timestamp: AnyValue, strict: boolean): IMOSTime {
 			throw new Error(`MosTime: Invalid input: "${timestamp}"`)
 		}
 	} else {
-		// no timestamp, create Date now:
-		time = new Date()
+		throw new Error(`MosTime: Invalid input: "${timestamp}"`)
 	}
 
 	if (isNaN(time.getTime())) {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This PR is posted on behalf of SuperFly.tv


## Type of Contribution

This is a: 
Code improvement. An attempt at making mos-connection better at handling off-spec messages.

This PR is another try at fixing the issues behind #84 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->



If we receive a message that is not according to the specification, like for example if calling `await mosDevice.requestMachineInfo()` and receiving the reply `<listMachInfo>`:

```xml
<listMachInfo>
	<manufacturer>RadioVision, Ltd.</manufacturer>
	<model>TCS6000</model>
	<hwRev>0</hwRev>
	<swRev>2.1.0.37</swRev>
	<DOM>0</DOM>
	<SN>927748927</SN>
	<ID>airchache.newscenter.com</ID>
	<time>2009-04-11T17:20:42</time>
	<opTime>2009-03-01T23:55:10</opTime>
	<mosRev>2.8.2</mosRev>
	<supportedProfiles deviceType="NCS">
		<mosProfile number="0">YES</mosProfile>
	</supportedProfiles>
	</listMachInfo>
```



1. If `<time>` is missing:  Returns an object where `time` is populated with a MosTime with value `Date.now()`
2. If `<time>` is empty: Throws with `Error: MosTime: Invalid input: \"[object Object]\"`
3. If `<time>` is badly formatted: Throws with `Error: MosTime: Invalid timestamp: \"BAD DATA\"`
4. If `<opTime>` is missing: Returns an object where `time` is populated with a MosTime with value `Date.now()`
5. If `<opTime>` is empty: Throws with `Error: MosTime: Invalid input: \"[object Object]\"`
6. If `<opTime>` is badly formatted: Throws with `Error: MosTime: Invalid timestamp: \"BAD DATA\"`

## Why this is bad:

(Note: According to the MOS protocol, `<time>` is required and `<opTime>` is optional.)

* How the library handles bad data is inconsistent: 1 and 2 (or 4 and 5) are arguably similar in xml-land, but treated very differently.
* When using the library, it is hard to figure out if the value in `<time>` is real or fictional (like in 1 or 4).


## New Behavior

If calling `await mosDevice.requestMachineInfo()`:

**If in _strict mode_**:

1. If `<time>` is missing: Throws with `Error: MosTime: Invalid input: "undefined"`
2. If `<time>` is empty: Throws with `Error: MosTime: Invalid input: "undefined"`
3. If `<time>` is badly formatted: Throws with `Error: MosTime: Invalid timestamp: "BAD DATA"`
5. If `<opTime>` is missing:  Returns an object where `opTime` is `undefined`.
6. If `<opTime>` is empty:  Returns an object where `opTime`  is `undefined`.
7. If `<opTime>` is badly formatted: Throws with `Error: MosTime: Invalid timestamp: "BAD DATA"`

**If in _non-strict mode_**:

1. If `<time>` is missing: Returns an object where the `time` field is populated with a MosTime with value `0`
2. If `<time>` is empty: Returns an object where the `time` field is populated with a MosTime with value `0`
3. If `<time>` is badly formatted: Throws with `Error: MosTime: Invalid timestamp: "BAD DATA"`
5. If `<opTime>` is missing: Returns an object where `opTime` is `undefined`
6. If `<opTime>` is empty: Returns an object where `opTime`  is `undefined`
8. If `<opTime>` is badly formatted: Throws with `Error: MosTime: Invalid timestamp: "BAD DATA"`

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

Basic regression testing should be enough.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
