### PR TITLE
fix!: proper support for Profile 1 <mosReqAll>, <mosObj> and <mosListAll> (SOFIE-2890)

### DIFF
--- a/packages/connector/src/__tests__/Profile0.spec.ts
+++ b/packages/connector/src/__tests__/Profile0.spec.ts
@@ -21,6 +21,7 @@ import { xmlData, xmlApiData } from '../__mocks__/testData'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 // @ts-ignore imports are unused
 import { Socket } from 'net'
+import { IMOSAck, IMOSAckStatus } from '@mos-connection/model'
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 beforeAll(() => {
@@ -44,6 +45,7 @@ describe('Profile 0', () => {
 	let onRequestMachineInfo: jest.Mock<any, any>
 	let onRequestMOSObject: jest.Mock<any, any>
 	let onRequestAllMOSObjects: jest.Mock<any, any>
+	let onMOSObjects: jest.Mock<any, any>
 
 	beforeAll(async () => {
 		mosConnection = await getMosConnection(
@@ -74,6 +76,17 @@ describe('Profile 0', () => {
 		})
 		mosDevice.onRequestAllMOSObjects(async (): Promise<Array<IMOSObject>> => {
 			return onRequestAllMOSObjects()
+		})
+		onMOSObjects = jest.fn(async (): Promise<IMOSAck> => {
+			return {
+				ID: mosTypes.mosString128.create(''),
+				Revision: 1,
+				Status: IMOSAckStatus.ACK,
+				Description: mosTypes.mosString128.create(''),
+			}
+		})
+		mosDevice.onMOSObjects(async (objs: IMOSObject[]): Promise<IMOSAck> => {
+			return onMOSObjects(objs)
 		})
 		const b = doBeforeAll()
 		socketMockLower = b.socketMockLower

--- a/packages/connector/src/__tests__/Profile0.spec.ts
+++ b/packages/connector/src/__tests__/Profile0.spec.ts
@@ -11,6 +11,7 @@ import {
 	getMosConnection,
 	getMosDevice,
 	getXMLReply,
+	mosTypes,
 	setupMocks,
 } from './lib'
 import { MosConnection, MosDevice, IMOSObject, IMOSListMachInfo } from '..'

--- a/packages/connector/src/__tests__/Profile2.spec.ts
+++ b/packages/connector/src/__tests__/Profile2.spec.ts
@@ -45,6 +45,7 @@ import { xml2js } from 'xml-js'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 // @ts-ignore imports are unused
 import { Socket } from 'net'
+import { IMOSAck, IMOSAckStatus } from '@mos-connection/model'
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 beforeAll(() => {
@@ -66,6 +67,8 @@ describe('Profile 2', () => {
 	let onRequestMachineInfo: jest.Mock<any, any>
 	let onRequestMOSObject: jest.Mock<any, any>
 	let onRequestAllMOSObjects: jest.Mock<any, any>
+	let onMOSObjects: jest.Mock<any, any>
+
 	let onCreateRunningOrder: jest.Mock<any, any>
 	let onReplaceRunningOrder: jest.Mock<any, any>
 	let onDeleteRunningOrder: jest.Mock<any, any>
@@ -121,6 +124,20 @@ describe('Profile 2', () => {
 		})
 		mosDevice.onRequestAllMOSObjects(async (): Promise<Array<IMOSObject>> => {
 			return onRequestAllMOSObjects()
+		})
+		mosDevice.onRequestAllMOSObjects(async (): Promise<Array<IMOSObject>> => {
+			return onRequestAllMOSObjects()
+		})
+		onMOSObjects = jest.fn(async (): Promise<IMOSAck> => {
+			return {
+				ID: mosTypes.mosString128.create(''),
+				Revision: 1,
+				Status: IMOSAckStatus.ACK,
+				Description: mosTypes.mosString128.create(''),
+			}
+		})
+		mosDevice.onMOSObjects(async (objs: IMOSObject[]): Promise<IMOSAck> => {
+			return onMOSObjects(objs)
 		})
 
 		// Profile 2:

--- a/packages/connector/src/__tests__/__snapshots__/Profile1.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile1.spec.ts.snap
@@ -542,6 +542,367 @@ exports[`Profile 1 onRequestMOSObject 2`] = `
 }
 `;
 
+exports[`Profile 1 receive mosListAll 1`] = `
+[
+  [
+    [
+      {
+        "AirStatus": undefined,
+        "Changed": {
+          "_mosTime": 1257086155000,
+          "_timezone": "Z",
+          "_timezoneOffset": 0,
+        },
+        "ChangedBy": {
+          "_mosString128": "Chris",
+        },
+        "Created": {
+          "_mosTime": 1257032352000,
+          "_timezone": "Z",
+          "_timezoneOffset": 0,
+        },
+        "CreatedBy": {
+          "_mosString128": "Chris",
+        },
+        "Description": {
+          "elements": [
+            {
+              "$name": "p",
+              "$type": "element",
+              "elements": [
+                {
+                  "$type": "text",
+                  "text": "Exterior footage of",
+                },
+                {
+                  "$name": "em",
+                  "$type": "text",
+                  "text": "Baley Park Hotel",
+                },
+                {
+                  "$type": "text",
+                  "text": "on fire with natural sound. Trucks are visible for the first portion of the clip.",
+                },
+                {
+                  "$name": "em",
+                  "$type": "text",
+                  "text": "CG locator at 0:04 and duration 0:05, Baley Park Hotel.",
+                },
+              ],
+            },
+            {
+              "$name": "p",
+              "$type": "element",
+              "elements": [
+                {
+                  "$name": "tab",
+                  "$type": "element",
+                },
+                {
+                  "$type": "text",
+                  "text": "Cuts to view of fire personnel exiting hotel lobby and cleaning up after the fire is out.",
+                },
+              ],
+            },
+            {
+              "$name": "p",
+              "$type": "element",
+              "em": "Clip has been doubled for pad on voice over.",
+            },
+          ],
+        },
+        "Duration": undefined,
+        "Group": undefined,
+        "ID": {
+          "_mosString128": "M000123",
+        },
+        "MosAbstract": undefined,
+        "Paths": [
+          {
+            "Description": "MPEG2 Video",
+            "Target": "\\server\\media\\clip392028cd2320s0d.mxf",
+            "Type": "PATH",
+          },
+          {
+            "Description": "WM9 750Kbps",
+            "Target": "https://server/proxy/clipe.wmv",
+            "Type": "PROXY PATH",
+          },
+          {
+            "Description": "MOS Object",
+            "Target": "https://server/proxy/clipe.xml",
+            "Type": "METADATA PATH",
+          },
+        ],
+        "Revision": undefined,
+        "Slug": {
+          "_mosString128": "HOTEL FIRE",
+        },
+        "Status": undefined,
+        "TimeBase": undefined,
+        "Type": undefined,
+      },
+      {
+        "AirStatus": "READY",
+        "Changed": {
+          "_mosTime": 1257088875000,
+          "_timezone": "Z",
+          "_timezoneOffset": 0,
+        },
+        "ChangedBy": {
+          "_mosString128": "Chris",
+        },
+        "Created": {
+          "_mosTime": 1257088741000,
+          "_timezone": "Z",
+          "_timezoneOffset": 0,
+        },
+        "CreatedBy": {
+          "_mosString128": "Phil",
+        },
+        "Description": "VOICE OVER MATERIAL OF COLSTAT MURDER SITES SHOT ON 1-NOV.",
+        "Duration": 800,
+        "Group": undefined,
+        "ID": {
+          "_mosString128": "M000224",
+        },
+        "MosAbstract": undefined,
+        "MosExternalMetaData": [
+          {
+            "MosPayload": {
+              "Approved": 0,
+              "Creator": "SHOLMES",
+              "ModBy": "LJOHNSTON",
+              "ModTime": 20010308142001,
+              "Owner": "SHOLMES",
+              "TextTime": 278,
+              "mediaTime": 0,
+              "text": 0,
+            },
+            "MosSchema": "https://MOSA4.com/mos/supported_schemas/MOSAXML2.08",
+            "MosScope": "STORY",
+          },
+        ],
+        "Paths": [
+          {
+            "Description": "MPEG2 Video",
+            "Target": "\\server\\media\\clip392028cd2320s0d.mxf",
+            "Type": "PATH",
+          },
+          {
+            "Description": "WM9 750Kbps",
+            "Target": "https://server/proxy/clipe.wmv",
+            "Type": "PROXY PATH",
+          },
+          {
+            "Description": "MOS Object",
+            "Target": "https://server/proxy/clipe.xml",
+            "Type": "METADATA PATH",
+          },
+        ],
+        "Revision": 4,
+        "Slug": {
+          "_mosString128": "COLSTAT MURDER:VO",
+        },
+        "Status": "UPDATED",
+        "TimeBase": 59.94,
+        "Type": "VIDEO",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`Profile 1 receive mosListAll 2`] = `
+{
+  "mos": {
+    "messageID": {
+      "_text": 1636,
+    },
+    "mosAck": {
+      "objID": {},
+      "objRev": {
+        "_text": 1,
+      },
+      "status": {
+        "_text": "ACK",
+      },
+      "statusDescription": {},
+    },
+    "mosID": {
+      "_text": "our.mos.id",
+    },
+    "ncsID": {
+      "_text": "their.mos.id",
+    },
+  },
+}
+`;
+
+exports[`Profile 1 receive mosObj 1`] = `
+[
+  [
+    [
+      {
+        "AirStatus": "READY",
+        "Changed": {
+          "_mosTime": 1257032352000,
+          "_timezone": "Z",
+          "_timezoneOffset": 0,
+        },
+        "ChangedBy": {
+          "_mosString128": "Chris",
+        },
+        "Created": {
+          "_mosTime": 1257032352000,
+          "_timezone": "Z",
+          "_timezoneOffset": 0,
+        },
+        "CreatedBy": {
+          "_mosString128": "Chris",
+        },
+        "Description": {
+          "elements": [
+            {
+              "$name": "p",
+              "$type": "element",
+              "elements": [
+                {
+                  "$type": "text",
+                  "text": "Exterior footage of",
+                },
+                {
+                  "$name": "em",
+                  "$type": "text",
+                  "text": "Baley Park Hotel",
+                },
+                {
+                  "$type": "text",
+                  "text": "on fire with natural sound. Trucks are visible for the first portion of the clip.",
+                },
+                {
+                  "$name": "em",
+                  "$type": "text",
+                  "text": "CG locator at 0:04 and duration 0:05, Baley Park Hotel.",
+                },
+              ],
+            },
+            {
+              "$name": "p",
+              "$type": "element",
+              "elements": [
+                {
+                  "$name": "tab",
+                  "$type": "element",
+                },
+                {
+                  "$type": "text",
+                  "text": "Cuts to view of fire personnel exiting hotel lobby and cleaning up after the fire is out.",
+                },
+              ],
+            },
+            {
+              "$name": "p",
+              "$type": "element",
+              "em": "Clip has been doubled for pad on voice over.",
+            },
+          ],
+        },
+        "Duration": 1800,
+        "Group": "Show 7",
+        "ID": {
+          "_mosString128": "M000123",
+        },
+        "MosAbstract": {
+          "elements": [
+            {
+              "$name": "b",
+              "$type": "text",
+              "text": "Hotel Fire",
+            },
+            {
+              "$name": "em",
+              "$type": "text",
+              "text": "vo",
+            },
+            {
+              "$type": "text",
+              "text": ":30",
+            },
+          ],
+        },
+        "MosExternalMetaData": [
+          {
+            "MosPayload": {
+              "Approved": 0,
+              "Creator": "SHOLMES",
+              "ModBy": "LJOHNSTON",
+              "ModTime": 20010308142001,
+              "Owner": "SHOLMES",
+              "TextTime": 278,
+              "mediaTime": 0,
+              "text": 0,
+            },
+            "MosSchema": "https://MOSA4.com/mos/supported_schemas/MOSAXML2.08",
+            "MosScope": "STORY",
+          },
+        ],
+        "Paths": [
+          {
+            "Description": "MPEG2 Video",
+            "Target": "\\server\\media\\clip392028cd2320s0d.mxf",
+            "Type": "PATH",
+          },
+          {
+            "Description": "WM9 750Kbps",
+            "Target": "https://server/proxy/clipe.wmv",
+            "Type": "PROXY PATH",
+          },
+          {
+            "Description": "MOS Object",
+            "Target": "https://server/proxy/clipe.xml",
+            "Type": "METADATA PATH",
+          },
+        ],
+        "Revision": 1,
+        "Slug": {
+          "_mosString128": "Hotel Fire",
+        },
+        "Status": "NEW",
+        "TimeBase": 59.94,
+        "Type": "VIDEO",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`Profile 1 receive mosObj 2`] = `
+{
+  "mos": {
+    "messageID": {
+      "_text": 1635,
+    },
+    "mosAck": {
+      "objID": {},
+      "objRev": {
+        "_text": 1,
+      },
+      "status": {
+        "_text": "ACK",
+      },
+      "statusDescription": {},
+    },
+    "mosID": {
+      "_text": "our.mos.id",
+    },
+    "ncsID": {
+      "_text": "their.mos.id",
+    },
+  },
+}
+`;
+
 exports[`Profile 1 sendMOSObject 1`] = `
 "<mos>
   <ncsID>their.mos.id</ncsID>

--- a/packages/connector/src/__tests__/api.spec.ts
+++ b/packages/connector/src/__tests__/api.spec.ts
@@ -117,7 +117,10 @@ test('api & exports', () => {
 			f = function (cb: () => Promise<Array<IMOSObject>>): void {
 				return mosDevice.onRequestAllMOSObjects(cb)
 			}
-			f = function (): Promise<Array<IMOSObject>> {
+			f = function (cb: (objs: IMOSObject[]) => Promise<IMOSAck>): void {
+				return mosDevice.onMOSObjects(cb)
+			}
+			f = function (): Promise<IMOSAck> {
 				return mosDevice.sendRequestAllMOSObjects()
 			}
 

--- a/packages/connector/src/api.ts
+++ b/packages/connector/src/api.ts
@@ -112,21 +112,37 @@ export interface IMOSDeviceProfile1 {
 
 	/**
 	 * Assign callback (as a MOS device) for when receiving message from NCS:
+	 * Contains information that describes a unique MOS Object to the NCS.
+	 * https://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm#mosObj
+	 * https://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm#mosListAll
+	 */
+	onMOSObjects: (cb: (objs: IMOSObject[]) => Promise<IMOSAck>) => void
+
+	/**
+	 * Assign callback (as a MOS device) for when receiving message from NCS:
 	 * Method for the NCS to request the MOS to send it a mosObj message for every Object in the MOS.
 	 * https://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm#mosReqAll
 	 */
 	onRequestAllMOSObjects: (cb: () => Promise<Array<IMOSObject>>) => void
 	/**
 	 * Method for the NCS to request the MOS to send it a mosObj message for every Object in the MOS.
+	 * The replies will be sent to the callback set up in onMOSObjects()
 	 * https://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm#mosReqAll
 	 */
-	sendRequestAllMOSObjects: () => Promise<Array<IMOSObject>>
+	sendRequestAllMOSObjects: (
+		/**
+		 * Pause, when greater than zero, indicates the number of seconds to pause between individual mosObj messages.
+		 * Pause of zero indicates that all objects will be sent using the mosListAll message.
+		 * @default 0
+		 */
+		pause?: number
+	) => Promise<IMOSAck>
 
 	// Deprecated methods:
 	/** @deprecated getMOSObject is deprecated, use sendRequestMOSObject instead */
 	getMOSObject: (objId: IMOSString128) => Promise<IMOSObject>
 	/** @deprecated getAllMOSObjects is deprecated, use sendRequestAllMOSObjects instead */
-	getAllMOSObjects: () => Promise<IMOSObject[]>
+	getAllMOSObjects: () => Promise<IMOSAck>
 }
 /**
  * Method definitions for Profile 2


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted by me on behalf of SuperFly.tv.

## Type of Contribution

This is a: 

**BREAKING** Feature 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

Disclaimer: To be honest, I think that the mos protocol spec is a tad unclear on how this REALLY should work, but I believe that this is how it _should be_. Ref: [Mos Protocol; mosReqAll](https://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm#mosReqAll).

Currently, when `mosDevice.sendRequestAllMOSObjects()` is called, a `<mosReqAll>` message is sent, and a `<mosListAll>` is expected as a reply.

This is not according to the spec, since there should be a  [mosAck](https://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm#mosAck), followed (_asynchronously on the other server initiated lower socket, I believe_) by  [mosListAll](https://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm#mosListAll) - if pause = 0, or [mosObj](https://mosprotocol.com/wp-content/MOS-Protocol-Documents/MOS-Protocol-2.8.4-Current.htm#mosObj) - if pause > 0.


## New Behavior
<!--
What is the new behavior?
-->

When `mosDevice.sendRequestAllMOSObjects()` is called, a `<mosReqAll>` message is sent, and a `<mosAck>` is expected as a reply.

Subsequent `<mosListAll>` or `<mosObj>` messages are parsed and triggers the callback set up using  `mosDevice.onMOSObjects(cb: (objs: IMOSObject[]) => void)`.

Since `mosDevice.onMOSObjects()` is now required to be set up for Profile 1 in strict mode, this PR is technically a breaking one.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

* If possible, testing with a MOS device to ensure that the exchange logic works.

(I have implemented this using the mos protocol only, not tested with other MOS devices.)


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
