### PR TITLE
fix: OpenMedia returns an empty object {} as time info

### DIFF
--- a/packages/model/src/mosTypes/mosTime.ts
+++ b/packages/model/src/mosTypes/mosTime.ts
@@ -57,7 +57,11 @@ export function create(timestamp: AnyValue, strict: boolean): IMOSTime {
 			} else if (timestamp?._mosTime !== undefined) {
 				time = new Date(timestamp._mosTime)
 			} else {
-				throw new Error(`MosTime: Invalid input: "${timestamp}"`)
+				if (strict) {
+					throw new Error(`MosTime: Invalid input: "${timestamp}"`)
+				} else {
+					time = new Date()
+				}
 			}
 		} else {
 			throw new Error(`MosTime: Invalid input: "${timestamp}"`)


### PR DESCRIPTION
## About the Contributor

This PR is hosted on behalf of BBC



## Type of Contribution

This is a: 
Bug fix
## Current Behavior

If the NRCS return an empty object instead of a time info or undefined, connection cannot be made.



## New Behavior

If not in strict mode, an empty time object will be set as current time.



## Testing Instructions

This but happens when connecting to OpenMedia


## Status

- [x ] PR is ready to be reviewed.
- [ x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
