### PR TITLE
feat: support for no messageId in non-strict mode

### DIFF
--- a/packages/connector/src/MosConnection.ts
+++ b/packages/connector/src/MosConnection.ts
@@ -82,7 +82,8 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 			this._conf.mosID,
 			connectionOptions.primary.timeout,
 			connectionOptions.primary.heartbeatInterval,
-			this._debug
+			this._debug,
+			this.mosTypes.strict
 		)
 		let secondary = null
 		this._ncsConnections[connectionOptions.primary.host] = primary
@@ -128,7 +129,8 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 				this._conf.mosID,
 				connectionOptions.secondary.timeout,
 				connectionOptions.secondary.heartbeatInterval,
-				this._debug
+				this._debug,
+				this.mosTypes.strict
 			)
 			this._ncsConnections[connectionOptions.secondary.host] = secondary
 			secondary.on('rawMessage', (type: string, message: string) => {
@@ -459,7 +461,8 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 						this._conf.mosID,
 						undefined,
 						undefined,
-						this._debug
+						this._debug,
+						this.mosTypes.strict
 					)
 					this._ncsConnections[remoteAddress] = primary
 

--- a/packages/connector/src/__tests__/__snapshots__/Profile0-non-strict.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile0-non-strict.spec.ts.snap
@@ -18,6 +18,15 @@ exports[`Profile 0 - non strict requestMachineInfo - empty <time> 1`] = `
 </mos>"
 `;
 
+exports[`Profile 0 - non strict requestMachineInfo - empty <time>, no messageId 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <reqMachInfo/>
+</mos>"
+`;
+
 exports[`Profile 0 - non strict requestMachineInfo - missing <opTime> 1`] = `
 "<mos>
   <ncsID>their.mos.id</ncsID>

--- a/packages/connector/src/__tests__/lib.ts
+++ b/packages/connector/src/__tests__/lib.ts
@@ -120,6 +120,8 @@ export function getXMLReply(
 	ourMosId?: string,
 	theirMosId?: string
 ): string {
+	//add field only if messageId exist
+	if(messageId) messageId = '<messageID>' + messageId + '</messageID>'
 	return (
 		'<mos>' +
 		'<mosID>' +
@@ -128,9 +130,7 @@ export function getXMLReply(
 		'<ncsID>' +
 		(theirMosId || 'their.mos.id') +
 		'</ncsID>' +
-		'<messageID>' +
 		messageId +
-		'</messageID>' +
 		content +
 		'</mos>\r\n'
 	)

--- a/packages/connector/src/connection/NCSServerConnection.ts
+++ b/packages/connector/src/connection/NCSServerConnection.ts
@@ -30,6 +30,7 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 	private _timeout: number
 	private _mosID: string
 	private _debug: boolean
+	private _strict: boolean = false
 	private _disposed = false
 
 	private _clients: { [clientID: string]: ClientDescription } = {}
@@ -45,7 +46,8 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 		mosID: string,
 		timeout: number | undefined,
 		heartbeatsInterval: number | undefined,
-		debug: boolean
+		debug: boolean,
+		strict:boolean
 	) {
 		super()
 		this._id = id
@@ -55,13 +57,14 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 		this._mosID = mosID
 		this._connected = false
 		this._debug = debug ?? false
+		this._strict = strict ?? false
 	}
 	get timeout(): number {
 		return this._timeout
 	}
 	/** Create a MOS client, which talks to  */
 	createClient(clientID: string, port: number, clientDescription: ConnectionType, useHeartbeats: boolean): void {
-		const client = new MosSocketClient(this._host, port, clientDescription, this._timeout, this._debug)
+		const client = new MosSocketClient(this._host, port, clientDescription, this._timeout, this._debug, this._strict)
 		this.debugTrace('registerOutgoingConnection', clientID)
 
 		this._clients[clientID] = {

--- a/packages/connector/src/connection/NCSServerConnection.ts
+++ b/packages/connector/src/connection/NCSServerConnection.ts
@@ -30,7 +30,7 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 	private _timeout: number
 	private _mosID: string
 	private _debug: boolean
-	private _strict: boolean = false
+	private _strict = false
 	private _disposed = false
 
 	private _clients: { [clientID: string]: ClientDescription } = {}
@@ -47,7 +47,7 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 		timeout: number | undefined,
 		heartbeatsInterval: number | undefined,
 		debug: boolean,
-		strict:boolean
+		strict: boolean
 	) {
 		super()
 		this._id = id
@@ -64,7 +64,14 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 	}
 	/** Create a MOS client, which talks to  */
 	createClient(clientID: string, port: number, clientDescription: ConnectionType, useHeartbeats: boolean): void {
-		const client = new MosSocketClient(this._host, port, clientDescription, this._timeout, this._debug, this._strict)
+		const client = new MosSocketClient(
+			this._host,
+			port,
+			clientDescription,
+			this._timeout,
+			this._debug,
+			this._strict
+		)
 		this.debugTrace('registerOutgoingConnection', clientID)
 
 		this._clients[clientID] = {

--- a/packages/connector/src/connection/mosSocketClient.ts
+++ b/packages/connector/src/connection/mosSocketClient.ts
@@ -443,28 +443,33 @@ export class MosSocketClient extends EventEmitter {
 		this.processQueue()
 	}
 
-	private _getMessageId(parsedData : any, messageString: string): string | undefined{
-        let messageId = parsedData.mos.messageID;
+	private _getMessageId(parsedData: any, messageString: string): string | undefined {
+		let messageId = parsedData.mos.messageID
 
-        if(!messageId){
-			if(this._strict){
+		if (!messageId) {
+			if (this._strict) {
 				this.debugTrace(`Reply with no messageId: ${messageString}. Try non-strict mode.`)
-			}
-			else{
-				if(this._sentMessage && this._sentMessage.msg.toString().search("<heartbeat>") >= 0 && parsedData.mos.heartbeat){  
+			} else {
+				if (
+					this._sentMessage &&
+					this._sentMessage.msg.toString().search('<heartbeat>') >= 0 &&
+					parsedData.mos.heartbeat
+				) {
 					messageId = this._sentMessage.msg.messageID
-				}
-				else if(this._sentMessage && this._sentMessage.msg.toString().search("<reqMachInfo/>") >= 0 && parsedData.mos.listMachInfo  ){
+				} else if (
+					this._sentMessage &&
+					this._sentMessage.msg.toString().search('<reqMachInfo/>') >= 0 &&
+					parsedData.mos.listMachInfo
+				) {
 					messageId = this._sentMessage.msg.messageID
-				}
-				else{
+				} else {
 					this.debugTrace(`Invalid reply with no messageId in non-strict mode: ${messageString}`)
 				}
 			}
-        }
+		}
 
-        return messageId
-    }
+		return messageId
+	}
 
 	/** */
 	private _onError(error: Error) {

--- a/packages/connector/src/connection/mosSocketClient.ts
+++ b/packages/connector/src/connection/mosSocketClient.ts
@@ -20,6 +20,7 @@ export class MosSocketClient extends EventEmitter {
 	private _reconnectDelay = 3000
 	private _reconnectAttempts = 0
 	private _debug: boolean
+	private _strict: boolean
 
 	private _description: string
 	private _client: Socket | undefined
@@ -48,13 +49,14 @@ export class MosSocketClient extends EventEmitter {
 	private messageParser: MosMessageParser
 
 	/** */
-	constructor(host: string, port: number, description: string, timeout: number, debug: boolean) {
+	constructor(host: string, port: number, description: string, timeout: number, debug: boolean, strict: boolean) {
 		super()
 		this._host = host
 		this._port = port
 		this._description = description
 		this._commandTimeout = timeout || DEFAULT_COMMAND_TIMEOUT
 		this._debug = debug ?? false
+		this._strict = strict ?? false
 
 		this.messageParser = new MosMessageParser(description)
 		this.messageParser.debug = this._debug


### PR DESCRIPTION

## About the Contributor
This PR is posted on behalf of CBC/Radio-Canada


## Type of Contribution

This is a: 
Feature


## Current Behavior
Relates to [issue 94](https://github.com/nrkno/sofie-mos-connection/issues/94). Message without messageId would cause the connection status to be "Bad - Primary: No heartbeats on upper"


## New Behavior
In non-strict mode, the messageId will be the last sent message id, if the message is a \<heartbeat> or a \<regMachInfo>.


## Testing Instructions
Tested with a MOS Gateway using MOS protocol 2.8 (with no messageId), and by checking/unchecking the (Optional) Strict MOS data handling checkbox in the MOS Gateway config. A test is provided as well in the packages/connector/src/__tests__/Profile0-non-strict.spec.ts file.


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
