### PR TITLE
WIP: objId was parsed as a number, and thus removed e.g. 00 

### DIFF
--- a/packages/helper/src/utils/__tests__/Utils.spec.ts
+++ b/packages/helper/src/utils/__tests__/Utils.spec.ts
@@ -146,3 +146,25 @@ test('xml2js with simple data', () => {
 		})
 	}
 })
+
+test('xml2js handle objID with nubmerformatting as string', () => {
+	const o: any = xml2js(`
+<content>
+	<navn>Jon Gelius</navn>
+	<objId>000987.6540</objId>
+	<tittel/>
+	<tematekst/>
+	<infotekst/>
+	<_valid>true</_valid>
+</content>
+	`)
+
+	expect(o.content).toEqual({
+		navn: 'Jon Gelius',
+		objId: '000987.6540',
+		tittel: {},
+		tematekst: {},
+		infotekst: {},
+		_valid: true,
+	})
+})


### PR DESCRIPTION
## About the Contributor
This PR was made on behalf of BBC

## Type of Contribution
Bug Fix for
https://github.com/nrkno/sofie-mos-connection/issues/92

## Current Behavior
If ObjID was a string that could be converted to a number (e.g. 00123.45600) all 00 around it would be removed.

## New Behavior
In xml2Js there's now a Set called `forcedStringObject` where all object name in it will be forced to be converted as a string.

## Testing Instructions
Create an obj with objID as a number, and ingest.

Helper Tests has also been updated for this. 

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
