### PR TITLE
Test for text with and without attributes

### DIFF
--- a/packages/helper/src/__tests__/parsing/mosSample3.json
+++ b/packages/helper/src/__tests__/parsing/mosSample3.json
@@ -1,0 +1,36 @@
+{
+	"items": [
+		{
+			"ID": "2",
+			"ObjectID": "cfc641849c417eaa10e4f3c377f181",
+			"MOSID": "parsing-text.sofie",
+			"Slug": "bts-finnmark-bil_with_attr(3)",
+			"Paths": [
+				{
+					"Description": "VIDEO",
+					"Target": "41cfc641849c417eaa10e4f3c377f181",
+					"Type": "PATH"
+				}
+			],
+			"MosExternalMetaData": [
+				{
+					"MosScope": "OBJECT",
+					"MosSchema": "http://mos-connection/unit-test",
+					"MosPayload": {
+						"objType": "VIDEO",
+						"zone": {
+							"name": "graphics",
+							"sequence": "weather-tower",
+							"variableNoAttr": "1,2,3,4",
+							"variable": {
+								"name": "locations",
+								"text": "1,2,3,4"
+							}
+						}
+					}
+				}
+			],
+			"ObjectSlug": "bts-finnmark-bil_with_attr(3)"
+		}
+	]
+}

--- a/packages/helper/src/__tests__/parsing/mosSample3.xml
+++ b/packages/helper/src/__tests__/parsing/mosSample3.xml
@@ -1,0 +1,28 @@
+<mos>
+	<ncsItem>
+		<item>
+			<itemID>2</itemID>
+			<itemSlug>bts-finnmark-bil_with_attr(3)</itemSlug>
+			<objID>cfc641849c417eaa10e4f3c377f181</objID>
+			<objSlug>bts-finnmark-bil_with_attr(3)</objSlug>
+			<mosID>parsing-text.sofie</mosID>
+			<mosPlugInID>Sofie.QuantelPlugin</mosPlugInID>
+			<mosAbstract />
+			<objPaths>
+				<objPath techDescription="VIDEO">41cfc641849c417eaa10e4f3c377f181</objPath>
+			</objPaths>
+			<itemEdDur />
+			<mosExternalMetadata>
+				<mosScope>OBJECT</mosScope>
+				<mosSchema>http://mos-connection/unit-test</mosSchema>
+				<mosPayload>
+					<objType>VIDEO</objType>
+					<zone name="graphics" sequence="weather-tower">
+						<variableNoAttr>1,2,3,4</variableNoAttr>
+						<variable name="locations">1,2,3,4</variable>
+					</zone>
+				</mosPayload>
+			</mosExternalMetadata>
+		</item>
+	</ncsItem>
+</mos>

--- a/packages/helper/src/__tests__/parsing/mosXml2Js.spec.ts
+++ b/packages/helper/src/__tests__/parsing/mosXml2Js.spec.ts
@@ -83,5 +83,29 @@ describe('MOS XML to JavaScript object parser', () => {
 				}
 			})
 		})
+		describe('Sample3 - test for singlepath with and without attributes', () => {
+			const sampleXmlStr = readFileSync(join(__dirname, './mosSample3.xml'), 'utf-8')
+			const sampleJsonStr = readFileSync(join(__dirname, './mosSample3.json'), 'utf-8')
+
+			const jsonDoc = JSON.parse(sampleJsonStr)
+
+			it('should match the json representation', () => {
+				const actual = parseMosPluginMessageXml(sampleXmlStr)
+				const actualJson = actual && stringifyMosObject(actual.items, true) // Strip out any MosString etc
+
+				expect(actualJson).toEqual(jsonDoc.items)
+			})
+
+			it('converting via xml should be lossless', () => {
+				for (let i = 0; i < jsonDoc.items.length; i++) {
+					const generatedXml = generateMosPluginItemXml(jsonDoc.items[i])
+					const actual = parseMosPluginMessageXml(generatedXml)
+
+					const actualJson = actual && stringifyMosObject(actual.items[0], true) // Strip out any MosString etc
+
+					expect(actualJson).toEqual(jsonDoc.items[i])
+				}
+			})
+		})
 	})
 })


### PR DESCRIPTION
## About the Contributor
This PR is made on behalf of BBC

## Type of Contribution

This is a test case improvement 

## Current Behavior
Prior to latest update bbc had an issue where single path text field with attributes wasn't parsed:
e.g. \<variable name="locations">1,2,3,4\</variable>
This seems to have been fixed in latest update.

## New Behavior
To ensure this not to happen in future changes this test case has been added.

## Testing Instructions
Run the tests.


## Other Information
There are no functional changes in this PR, and if this is already covered in some other test, we can just close this PR.

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
